### PR TITLE
HMAC authenticaion method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,14 @@
     },
     "require": {
         "php-http/httplug": "^1.1",
-        "php-http/message": "^1.0",
+        "php-http/message-factory": "^1.0",
         "php-http/client-implementation": "^1.0",
         "php-http/discovery": "^1.0"
     },
     "require-dev": {
         "php-http/guzzle6-adapter": "^1.1",
+        "php-http/mock-client": "^1.0",
+        "php-http/message": "^1.0",
         "phpunit/phpunit": "^5.7 || ^6.4",
         "friendsofphp/php-cs-fixer": "^2.7",
         "phpstan/phpstan-shim": "^0.8.5",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,9 @@
         "phpunit/phpunit": "^5.7 || ^6.4",
         "friendsofphp/php-cs-fixer": "^2.7",
         "phpstan/phpstan-shim": "^0.8.5",
-        "php-coveralls/php-coveralls": "^1.0"
+        "php-coveralls/php-coveralls": "^1.0",
+        "symfony/var-dumper": "^3.3",
+        "php-mock/php-mock-phpunit": "^2.0"
     },
     "scripts": {
         "test": [

--- a/src/Http/HmacAuthentication.php
+++ b/src/Http/HmacAuthentication.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Http;
+
+use Http\Message\Authentication;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Use api key to sign request with hmac_timestamp and hmac_sign query parameters.
+ */
+class HmacAuthentication implements Authentication
+{
+    /** @var string */
+    private $apiKey;
+
+    public function __construct(string $apiKey)
+    {
+        $this->apiKey = $apiKey;
+    }
+
+    public function authenticate(RequestInterface $request): RequestInterface
+    {
+        $params = $this->addAuthenticationToParamsFromRequest($request);
+
+        return $this->createRequestWithParams($request, $params);
+    }
+
+    private function addAuthenticationToParamsFromRequest(RequestInterface $request): array
+    {
+        $params = $this->parseQueryParamsFromRequest($request);
+
+        $params['hmac_timestamp'] = time();
+
+        $unsignedRequest = $this->createRequestWithParams($request, $params);
+
+        $params['hmac_sign'] = hash_hmac('sha1', $unsignedRequest->getRequestTarget(), $this->apiKey);
+
+        return $params;
+    }
+
+    private function parseQueryParamsFromRequest(RequestInterface $request): array
+    {
+        $uri = $request->getUri();
+        $query = $uri->getQuery();
+
+        $params = [];
+        parse_str($query, $params);
+
+        return $params;
+    }
+
+    private function createRequestWithParams(RequestInterface $request, array $params): RequestInterface
+    {
+        $uri = $request->getUri();
+
+        $query = http_build_query($params);
+        $uri = $uri->withQuery($query);
+
+        return $request->withUri($uri);
+    }
+}

--- a/tests/Http/HmacAuthenticationTest.php
+++ b/tests/Http/HmacAuthenticationTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Http;
+
+use phpmock\phpunit\PHPMock;
+use PHPUnit\Framework\TestCase;
+
+class HmacAuthenticationTest extends TestCase
+{
+    const TIMESTAMP = 1510230813;
+    const APIKEY = 'foobar';
+
+    use PHPMock;
+
+    /**
+     * @test
+     * @dataProvider provideUris
+     */
+    public function shouldSignRequest(string $originalPath, string $expectedSingedPath): void
+    {
+        $time = $this->getFunctionMock(__NAMESPACE__, 'time');
+        $time->expects($this->any())->willReturn(self::TIMESTAMP);
+
+        $authentication = new HmacAuthentication(self::APIKEY);
+        $unsignedRequest = new \GuzzleHttp\Psr7\Request('GET', 'http://foo.com' . $originalPath);
+
+        $signedRequest = $authentication->authenticate($unsignedRequest);
+
+        $this->assertSame($expectedSingedPath, $signedRequest->getRequestTarget());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideUris(): array
+    {
+        // expected values were pre-signed using TIMESTAMP and APIKEY
+        return [
+            'root path' => [
+                '/',
+                '/?hmac_timestamp=' . self::TIMESTAMP . '&hmac_sign=88e50f71a0327c7566a34f5e9c0441e0a355d12e',
+            ],
+            'path without query' => [
+                '/endpoint',
+                '/endpoint?hmac_timestamp=' . self::TIMESTAMP . '&hmac_sign=03ad5cbdda7539fcd8f918a6630de23e092bf94e',
+            ],
+            'path with one query param' => [
+                '/endpoint?foo=bar',
+                '/endpoint?foo=bar&hmac_timestamp=' . self::TIMESTAMP
+                . '&hmac_sign=aa6cf8743172b344aa8b75b45b19c219d20298a2',
+            ],
+            'path with multiple query params' => [
+                '/endpoint?foo=bar&ban[]=baz&ban[]=bat',
+                '/endpoint?foo=bar&ban%5B0%5D=baz&ban%5B1%5D=bat&hmac_timestamp=' . self::TIMESTAMP
+                . '&hmac_sign=486b98665ab883dc79666033a8e0d976fedcf88d',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Only a basic building block of client internals.

Will be used as [custom authentication method](http://docs.php-http.org/en/latest/message/authentication.html#implement-your-own) of HTTPlug [Authentication plugin](http://docs.php-http.org/en/latest/plugins/authentication.html).

Something like
```php
new PluginClient(
    HttpClientDiscovery::find(),
    [
        new AuthenticationPlugin(new HmacAuthentication($this->apiKey)),
    ]
);
```
(This will be part of Matej\Client internals, so end-clients will not have to set it up.)