### PR TITLE
Exception handling plugin

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -9,6 +9,7 @@ return PhpCsFixer\Config::create()
         'array_syntax' => ['syntax' => 'short'],
         'binary_operator_spaces' => true,
         'blank_line_before_return' => true,
+        'braces' => ['allow_single_line_closure' => true],
         'cast_spaces' => true,
         'concat_space' => ['spacing' => 'one'],
         'declare_strict_types' => true,

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "php-http/message-factory": "^1.0",
         "php-http/client-implementation": "^1.0",
         "php-http/discovery": "^1.0",
-        "fig/http-message-util": "^1.1"
+        "fig/http-message-util": "^1.1",
+        "php-http/client-common": "^1.6"
     },
     "require-dev": {
         "php-http/guzzle6-adapter": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "php-http/httplug": "^1.1",
         "php-http/message-factory": "^1.0",
         "php-http/client-implementation": "^1.0",
-        "php-http/discovery": "^1.0"
+        "php-http/discovery": "^1.0",
+        "fig/http-message-util": "^1.1"
     },
     "require-dev": {
         "php-http/guzzle6-adapter": "^1.1",
@@ -43,7 +44,7 @@
             "./vendor/bin/phpunit"
         ],
         "check": [
-            "vendor/bin/php-cs-fixer fix --diff --dry-run --ansi",
+            "vendor/bin/php-cs-fixer fix -vvv --diff --dry-run --ansi",
             "vendor/bin/phpstan.phar analyze ./src ./tests --level 7 --ansi"
         ]
     }

--- a/src/Exception/AbstractMatejException.php
+++ b/src/Exception/AbstractMatejException.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Exception;
+
+/**
+ * Common parent of all exceptions thrown from Matej API Client.
+ */
+abstract class AbstractMatejException extends \RuntimeException
+{
+}

--- a/src/Exception/AuthorizationException.php
+++ b/src/Exception/AuthorizationException.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Exception;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Exception thrown when request authorization fails.
+ */
+class AuthorizationException extends RequestException
+{
+    public static function createFromRequestAndResponse(
+        RequestInterface $request,
+        ResponseInterface $response,
+        \Throwable $previous = null
+    ): self {
+        $responseData = json_decode($response->getBody()->getContents());
+
+        $message = sprintf(
+            'Matej API authorization error for url "%s"%s',
+            $request->getRequestTarget(),
+            isset($responseData->message) ? ' (' . $responseData->message . ')' : ''
+        );
+
+        return new static($message, $request, $response, $previous);
+    }
+}

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Exception;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Generic exception thrown when error occurs during request execution.
+ * Some more specific child exception could be thrown instead.
+ */
+class RequestException extends AbstractMatejException
+{
+    /** @var RequestInterface */
+    private $request;
+    /** @var ResponseInterface */
+    private $response;
+
+    public function __construct(
+        string $message,
+        RequestInterface $request,
+        ResponseInterface $response,
+        \Throwable $previous = null
+    ) {
+        $code = $response->getStatusCode();
+        $this->request = $request;
+        $this->response = $response;
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getRequest(): RequestInterface
+    {
+        return $this->request;
+    }
+
+    public function getResponse(): ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Http/Plugin/ExceptionPlugin.php
+++ b/src/Http/Plugin/ExceptionPlugin.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Http\Plugin;
+
+use Fig\Http\Message\StatusCodeInterface;
+use Http\Client\Common\Plugin;
+use Http\Promise\Promise;
+use Lmc\Matej\Exception\AuthorizationException;
+use Lmc\Matej\Exception\RequestException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class ExceptionPlugin implements Plugin
+{
+    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
+    {
+        /** @var Promise $promise */
+        $promise = $next($request);
+
+        return $promise->then(function (ResponseInterface $response) use ($request) {
+            return $this->transformResponseToException($request, $response);
+        });
+    }
+
+    private function transformResponseToException(RequestInterface $request, ResponseInterface $response)
+    {
+        $responseCode = $response->getStatusCode();
+
+        if ($responseCode === StatusCodeInterface::STATUS_UNAUTHORIZED) {
+            throw AuthorizationException::createFromRequestAndResponse($request, $response);
+        }
+
+        if ($responseCode >= 400 && $responseCode < 600) {
+            // TODO: use more specific exceptions
+            throw new RequestException($response->getReasonPhrase(), $request, $response);
+        }
+
+        return $response;
+    }
+}

--- a/tests/Exception/AuthorizationExceptionTest.php
+++ b/tests/Exception/AuthorizationExceptionTest.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Lmc\Matej\Exception;
+
+use Fig\Http\Message\StatusCodeInterface;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+class AuthorizationExceptionTest extends TestCase
+{
+    /** @test */
+    public function shouldCreateExceptionFromJsonResponse(): void
+    {
+        $request = new Request('GET', 'http://foo.com/endpoint');
+
+        $response = new Response(
+            StatusCodeInterface::STATUS_UNAUTHORIZED,
+            ['Content-Type' => 'application/json'],
+            '{"message": "Invalid signature. Check your secret key","result": "ERROR"}'
+        );
+
+        $exception = AuthorizationException::createFromRequestAndResponse($request, $response);
+
+        $this->assertInstanceOf(AuthorizationException::class, $exception);
+        $this->assertSame(
+            'Matej API authorization error for url "/endpoint" (Invalid signature. Check your secret key)',
+            $exception->getMessage()
+        );
+        $this->assertSame(StatusCodeInterface::STATUS_UNAUTHORIZED, $exception->getCode());
+        $this->assertSame($request, $exception->getRequest());
+        $this->assertSame($response, $exception->getResponse());
+    }
+}

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Exception;
+
+use Fig\Http\Message\StatusCodeInterface;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+class RequestExceptionTest extends TestCase
+{
+    /** @test */
+    public function shouldConstructNewException(): void
+    {
+        $message = 'Foo bar baz message';
+        $request = new Request('GET', 'http://foo.com');
+        $response = new Response(StatusCodeInterface::STATUS_NOT_FOUND);
+
+        $exception = new RequestException($message, $request, $response);
+
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(StatusCodeInterface::STATUS_NOT_FOUND, $exception->getCode());
+        $this->assertSame($request, $exception->getRequest());
+        $this->assertSame($response, $exception->getResponse());
+    }
+}

--- a/tests/Http/Plugin/ExceptionPluginTest.php
+++ b/tests/Http/Plugin/ExceptionPluginTest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace Lmc\Matej\Http\Plugin;
+
+use Fig\Http\Message\StatusCodeInterface;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Http\Client\Promise\HttpFulfilledPromise;
+use Lmc\Matej\Exception\AuthorizationException;
+use Lmc\Matej\Exception\RequestException;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+class ExceptionPluginTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider provideSuccessStatusCodes
+     */
+    public function shouldReturnResponseWhenNoError(int $statusCode): void
+    {
+        $request = new Request('GET', 'http://foo.com/endpoint');
+        $response = new Response($statusCode);
+
+        $next = function (RequestInterface $receivedRequest) use ($request, $response) {
+            $this->assertSame($request, $receivedRequest);
+
+            return new HttpFulfilledPromise($response);
+        };
+
+        $plugin = new ExceptionPlugin();
+        $promise = $plugin->handleRequest($request, $next, function (): void {});
+        $this->assertInstanceOf(HttpFulfilledPromise::class, $promise);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideSuccessStatusCodes(): array
+    {
+        return [
+            'HTTP 200' => [StatusCodeInterface::STATUS_OK, RequestException::class],
+            'HTTP 201' => [StatusCodeInterface::STATUS_CREATED, AuthorizationException::class],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider provideErrorStatusCodes
+     */
+    public function shouldThrowExceptionBasedOnStatusCode(int $statusCode, string $expectedExceptionClass): void
+    {
+        $request = new Request('GET', 'http://foo.com/endpoint');
+        $response = new Response($statusCode);
+
+        $next = function (RequestInterface $receivedRequest) use ($request, $response) {
+            $this->assertSame($request, $receivedRequest);
+
+            return new HttpFulfilledPromise($response);
+        };
+
+        $plugin = new ExceptionPlugin();
+
+        $this->expectException($expectedExceptionClass);
+        $plugin->handleRequest($request, $next, function (): void {});
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideErrorStatusCodes(): array
+    {
+        return [
+            'HTTP 400' => [StatusCodeInterface::STATUS_BAD_REQUEST, RequestException::class],
+            'HTTP 401' => [StatusCodeInterface::STATUS_UNAUTHORIZED, AuthorizationException::class],
+            'HTTP 404' => [StatusCodeInterface::STATUS_NOT_FOUND, RequestException::class],
+            'HTTP 500' => [StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR, RequestException::class],
+            'Imaginary HTTP 599' => [599, RequestException::class],
+        ];
+    }
+}


### PR DESCRIPTION
Also part of the internal HTTP layer. Will transfer error responses from Matej API to custom Exceptions.

It will be used internally in the library as another HTTPlug request plugin (http://docs.php-http.org/en/latest/plugins/build-your-own.html).

```php
$pluginClient = new PluginClient(
    $this->getHttpClient(),
    [
        // ... other plugins, like AuthenticationPlugin
        new ExceptionPlugin(),
    ]
);
```