### PR TITLE
Rename package to lmc/matej-client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "lmc/matej",
+    "name": "lmc/matej-client",
     "description": "API Client for Matej recommendation engine",
     "type": "library",
     "license": "MIT",


### PR DESCRIPTION
Just FYI.

Packagist package will be `lmc/matej-client`.
And the repository is already renamed to `lmc-eu/matej-client-php`