### PR TITLE
Response decoding

### DIFF
--- a/src/Exception/AuthorizationException.php
+++ b/src/Exception/AuthorizationException.php
@@ -10,7 +10,7 @@ use Psr\Http\Message\ResponseInterface;
  */
 class AuthorizationException extends RequestException
 {
-    public static function createFromRequestAndResponse(
+    public static function fromRequestAndResponse(
         RequestInterface $request,
         ResponseInterface $response,
         \Throwable $previous = null

--- a/src/Exception/InvalidDomainModelArgumentException.php
+++ b/src/Exception/InvalidDomainModelArgumentException.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Exception;
+
+/**
+ * Exception thrown when invalid argument is passed while creating domain model.
+ */
+class InvalidDomainModelArgumentException extends AbstractMatejException
+{
+    public static function forInconsistentNumberOfCommands(
+        int $numberOfCommands,
+        int $commandResponsesCount
+    ): self {
+        return new self(
+            sprintf(
+                'Provided numberOfCommands (%d) is inconsistent with actual count of command responses (%d)',
+                $numberOfCommands,
+                $commandResponsesCount
+            )
+        );
+    }
+
+    public static function forInconsistentNumbersOfCommandProperties(
+        int $numberOfCommands,
+        $numberOfSuccessfulCommands,
+        $numberOfFailedCommands
+    ): self {
+        return new self(
+            sprintf(
+                'Provided numberOfCommands (%d) is inconsistent with provided sum of '
+                . 'numberOfSuccessfulCommands (%d) and numberOfFailedCommands (%d)',
+                $numberOfCommands,
+                $numberOfSuccessfulCommands,
+                $numberOfFailedCommands
+            )
+        );
+    }
+}

--- a/src/Exception/ResponseDecodingException.php
+++ b/src/Exception/ResponseDecodingException.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Exception;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Exception thrown when Matej response cannot be decoded.
+ */
+class ResponseDecodingException extends AbstractMatejException
+{
+    public static function forJsonError(string $jsonErrorMsg, ResponseInterface $response): self
+    {
+        return new self(
+            sprintf(
+                "Error decoding Matej response: %s\n\nStatus code: %s %s\nBody:\n%s",
+                $jsonErrorMsg,
+                $response->getStatusCode(),
+                $response->getReasonPhrase(),
+                $response->getBody()
+            )
+        );
+    }
+}

--- a/src/Http/Plugin/ExceptionPlugin.php
+++ b/src/Http/Plugin/ExceptionPlugin.php
@@ -27,7 +27,7 @@ final class ExceptionPlugin implements Plugin
         $responseCode = $response->getStatusCode();
 
         if ($responseCode === StatusCodeInterface::STATUS_UNAUTHORIZED) {
-            throw AuthorizationException::createFromRequestAndResponse($request, $response);
+            throw AuthorizationException::fromRequestAndResponse($request, $response);
         }
 
         if ($responseCode >= 401 && $responseCode < 600) {

--- a/src/Http/ResponseDecoder.php
+++ b/src/Http/ResponseDecoder.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Http;
+
+use Lmc\Matej\Exception\ResponseDecodingException;
+use Lmc\Matej\Model\Response;
+use Psr\Http\Message\ResponseInterface;
+
+class ResponseDecoder implements ResponseDecoderInterface
+{
+    public function decode(ResponseInterface $httpResponse): Response
+    {
+        $responseData = json_decode($httpResponse->getBody()->getContents());
+
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw ResponseDecodingException::forJsonError(json_last_error_msg(), $httpResponse);
+        }
+
+        return new Response(
+            (int) $responseData->commands->number_of_commands,
+            (int) $responseData->commands->number_of_successful_commands,
+            (int) $responseData->commands->number_of_failed_commands,
+            $responseData->commands->responses
+        );
+    }
+}

--- a/src/Http/ResponseDecoderInterface.php
+++ b/src/Http/ResponseDecoderInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Lmc\Matej\Http;
+
+use Lmc\Matej\Model\Response;
+use Psr\Http\Message\ResponseInterface;
+
+interface ResponseDecoderInterface
+{
+    public function decode(ResponseInterface $httpResponse): Response;
+}

--- a/src/Model/CommandResponse.php
+++ b/src/Model/CommandResponse.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model;
+
+use Lmc\Matej\Exception\InvalidDomainModelArgumentException;
+
+/**
+ * Response to one single command which was part of request batch.
+ */
+class CommandResponse
+{
+    const STATUS_OK = 'OK';
+    const STATUS_ERROR = 'ERROR';
+    const STATUS_SKIPPED = 'SKIPPED';
+
+    /** @var string */
+    private $status;
+    /** @var string */
+    private $message;
+    /** @var array */
+    private $data = [];
+
+    private function __construct()
+    {
+    }
+
+    public static function createFromRawCommandResponseObject(\stdClass $rawCommandResponseObject): self
+    {
+        if (!isset($rawCommandResponseObject->status)) {
+            throw new InvalidDomainModelArgumentException('Status field is missing in command response object');
+        }
+
+        $commandResponse = new self();
+        $commandResponse->status = $rawCommandResponseObject->status;
+        $commandResponse->message = $rawCommandResponseObject->message ?? '';
+        $commandResponse->data = $rawCommandResponseObject->data ?? [];
+
+        return $commandResponse;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Model/Response.php
+++ b/src/Model/Response.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model;
+
+use Lmc\Matej\Exception\InvalidDomainModelArgumentException;
+
+class Response
+{
+    /** @var CommandResponse[] */
+    private $commandResponses = [];
+    /** @var int */
+    private $numberOfCommands;
+    /** @var int */
+    private $numberOfSuccessfulCommands;
+    /** @var int */
+    private $numberOfFailedCommands;
+
+    public function __construct(
+        int $numberOfCommands,
+        int $numberOfSuccessfulCommands,
+        int $numberOfFailedCommands,
+        array $commandResponses = []
+    ) {
+        $this->numberOfCommands = $numberOfCommands;
+        $this->numberOfSuccessfulCommands = $numberOfSuccessfulCommands;
+        $this->numberOfFailedCommands = $numberOfFailedCommands;
+
+        foreach ($commandResponses as $rawCommandResponse) {
+            $this->commandResponses[] = CommandResponse::createFromRawCommandResponseObject($rawCommandResponse);
+        }
+
+        if ($this->numberOfCommands !== count($commandResponses)) {
+            throw  InvalidDomainModelArgumentException::forInconsistentNumberOfCommands(
+                $this->numberOfCommands,
+                count($commandResponses)
+            );
+        }
+
+        if ($this->numberOfCommands !== ($this->numberOfSuccessfulCommands + $this->numberOfFailedCommands)) {
+            throw InvalidDomainModelArgumentException::forInconsistentNumbersOfCommandProperties(
+                $this->numberOfCommands,
+                $this->numberOfSuccessfulCommands,
+                $this->numberOfFailedCommands
+            );
+        }
+    }
+
+    public function getNumberOfCommands(): int
+    {
+        return $this->numberOfCommands;
+    }
+
+    public function getNumberOfSuccessfulCommands(): int
+    {
+        return $this->numberOfSuccessfulCommands;
+    }
+
+    public function getNumberOfFailedCommands(): int
+    {
+        return $this->numberOfFailedCommands;
+    }
+
+    /**
+     * Each Command which was part of request batch has here corresponding CommandResponse - on the same index on which
+     * the Command was added to the request batch.
+     *
+     * @return CommandResponse[]
+     */
+    public function getCommandResponses(): array
+    {
+        return $this->commandResponses;
+    }
+}

--- a/tests/Exception/AuthorizationExceptionTest.php
+++ b/tests/Exception/AuthorizationExceptionTest.php
@@ -21,7 +21,7 @@ class AuthorizationExceptionTest extends TestCase
             '{"message": "Invalid signature. Check your secret key","result": "ERROR"}'
         );
 
-        $exception = AuthorizationException::createFromRequestAndResponse($request, $response);
+        $exception = AuthorizationException::fromRequestAndResponse($request, $response);
 
         $this->assertInstanceOf(AuthorizationException::class, $exception);
         $this->assertSame(

--- a/tests/Http/Fixtures/invalid-json.html
+++ b/tests/Http/Fixtures/invalid-json.html
@@ -1,0 +1,7 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+<html><head>
+<title>404 Not Found</title>
+</head><body>
+<h1>Not Found</h1>
+<p>The requested URL /foo was not found on this server.</p>
+</body></html>

--- a/tests/Http/Fixtures/response-item-properties.json
+++ b/tests/Http/Fixtures/response-item-properties.json
@@ -1,0 +1,26 @@
+{
+  "commands": {
+    "number_of_commands": 3,
+    "number_of_failed_commands": 1,
+    "number_of_successful_commands": 2,
+    "responses": [
+      {
+        "data": [],
+        "message": "",
+        "status": "OK"
+      },
+      {
+        "data": [],
+        "message": "DuplicateKeyError(u'E11000 duplicate key error collection: foo.data_items_properties index: property_1 dup key: { : \"title\" }',)",
+        "status": "ERROR"
+      },
+      {
+        "data": [],
+        "message": "",
+        "status": "OK"
+      }
+    ]
+  },
+  "message": "",
+  "status": "OK"
+}

--- a/tests/Http/Fixtures/response-one-successful-command.json
+++ b/tests/Http/Fixtures/response-one-successful-command.json
@@ -1,0 +1,16 @@
+{
+  "commands": {
+    "number_of_commands": 1,
+    "number_of_failed_commands": 0,
+    "number_of_successful_commands": 1,
+    "responses": [
+      {
+        "data": [],
+        "message": "",
+        "status": "OK"
+      }
+    ]
+  },
+  "message": "",
+  "status": "OK"
+}

--- a/tests/Http/ResponseDecoderTest.php
+++ b/tests/Http/ResponseDecoderTest.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace Lmc\Matej\Http;
+
+use Fig\Http\Message\StatusCodeInterface;
+use GuzzleHttp\Psr7\Response;
+use Lmc\Matej\Exception\ResponseDecodingException;
+use Lmc\Matej\Model\CommandResponse;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+class ResponseDecoderTest extends TestCase
+{
+    /** @var ResponseDecoder */
+    protected $decoder;
+
+    /** @before */
+    public function init(): void
+    {
+        $this->decoder = new ResponseDecoder();
+    }
+
+    /** @test */
+    public function shouldDecodeSimpleOkResponse(): void
+    {
+        $response = $this->createJsonResponseFromFile(__DIR__ . '/Fixtures/response-one-successful-command.json');
+
+        $output = $this->decoder->decode($response);
+
+        $this->assertSame(1, $output->getNumberOfCommands());
+        $this->assertSame(1, $output->getNumberOfSuccessfulCommands());
+        $this->assertSame(0, $output->getNumberOfFailedCommands());
+
+        $commandResponses = $output->getCommandResponses();
+        $this->assertCount(1, $commandResponses);
+        $this->assertInstanceOf(CommandResponse::class, $commandResponses[0]);
+        $this->assertSame(CommandResponse::STATUS_OK, $commandResponses[0]->getStatus());
+    }
+
+    /** @test */
+    public function shouldDecodeResponseMultipleResponses(): void
+    {
+        $response = $this->createJsonResponseFromFile(__DIR__ . '/Fixtures/response-item-properties.json');
+
+        $output = $this->decoder->decode($response);
+
+        $this->assertSame(3, $output->getNumberOfCommands());
+        $this->assertSame(2, $output->getNumberOfSuccessfulCommands());
+        $this->assertSame(1, $output->getNumberOfFailedCommands());
+
+        $commandResponses = $output->getCommandResponses();
+        $this->assertCount(3, $commandResponses);
+        $this->assertContainsOnlyInstancesOf(CommandResponse::class, $commandResponses);
+        $this->assertSame(CommandResponse::STATUS_OK, $commandResponses[0]->getStatus());
+        $this->assertSame(CommandResponse::STATUS_ERROR, $commandResponses[1]->getStatus());
+        $this->assertSame(CommandResponse::STATUS_OK, $commandResponses[2]->getStatus());
+    }
+
+    /** @test */
+    public function shouldThrowExceptionWhenDecodingFails(): void
+    {
+        $notJsonData = file_get_contents(__DIR__ . '/Fixtures/invalid-json.html');
+        $response = new Response(StatusCodeInterface::STATUS_NOT_FOUND, [], $notJsonData);
+
+        $this->expectException(ResponseDecodingException::class);
+        $this->expectExceptionMessage('Error decoding Matej response');
+        $this->expectExceptionMessage('Status code: 404 Not Found');
+        $this->expectExceptionMessage('<p>The requested URL /foo was not found on this server.</p>');
+        $this->decoder->decode($response);
+    }
+
+    private function createJsonResponseFromFile(string $fileName): ResponseInterface
+    {
+        $jsonData = file_get_contents($fileName);
+        $response = new Response(StatusCodeInterface::STATUS_OK, ['Content-Type' => 'application/json'], $jsonData);
+
+        return $response;
+    }
+}

--- a/tests/Model/CommandResponseTest.php
+++ b/tests/Model/CommandResponseTest.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace Lmc\Matej\Model;
+
+use Lmc\Matej\Exception\InvalidDomainModelArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class CommandResponseTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider provideObjectResponses
+     */
+    public function shouldBeInstantiableFromRawObject(
+        \stdClass $objectResponse,
+        string $expectedStatus,
+        string $expectedMessage,
+        array $expectedData
+    ): void {
+        $commandResponse = CommandResponse::createFromRawCommandResponseObject($objectResponse);
+
+        $this->assertInstanceOf(CommandResponse::class, $commandResponse);
+        $this->assertSame($expectedStatus, $commandResponse->getStatus());
+        $this->assertSame($expectedMessage, $commandResponse->getMessage());
+        $this->assertSame($expectedData, $commandResponse->getData());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideObjectResponses(): array
+    {
+        return [
+            'OK response with only status' => [
+                (object) ['status' => 'OK'],
+                'OK',
+                '',
+                [],
+            ],
+            'OK response with status and empty message and data' => [
+                (object) ['status' => 'OK', 'message' => '', 'data' => []],
+                'OK',
+                '',
+                [],
+            ],
+            'OK response with all fields' => [
+                (object) ['status' => 'OK', 'message' => 'Nice!', 'data' => [['foo' => 'bar'], ['baz' => 'bak']]],
+                'OK',
+                'Nice!',
+                [['foo' => 'bar'], ['baz' => 'bak']],
+            ],
+            'Error response with status and message' => [
+                (object) ['status' => 'ERROR', 'message' => 'DuplicateKeyError(Duplicate key error collection)'],
+                'ERROR',
+                'DuplicateKeyError(Duplicate key error collection)',
+                [],
+            ],
+        ];
+    }
+
+    /** @test */
+    public function shouldThrowExceptionIfStatusIsMissing(): void
+    {
+        $this->expectException(InvalidDomainModelArgumentException::class);
+        $this->expectExceptionMessage('Status field is missing in command response object');
+        CommandResponse::createFromRawCommandResponseObject((object) ['message' => 'Foo', 'data' => [['bar']]]);
+    }
+}

--- a/tests/Model/ResponseTest.php
+++ b/tests/Model/ResponseTest.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+namespace Lmc\Matej\Model;
+
+use Lmc\Matej\Exception\InvalidDomainModelArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class ResponseTest extends TestCase
+{
+    /**
+     * @dataProvider provideResponseData
+     * @test
+     */
+    public function shouldBeInstantiable(
+        int $numberOfCommands,
+        int $numberOfSuccessfulCommands,
+        int $numberOfFailedCommands,
+        array $commandResponses
+    ): void {
+        $response = new Response(
+            $numberOfCommands,
+            $numberOfSuccessfulCommands,
+            $numberOfFailedCommands,
+            $commandResponses
+        );
+
+        $this->assertSame($numberOfCommands, $response->getNumberOfCommands());
+        $this->assertSame($numberOfSuccessfulCommands, $response->getNumberOfSuccessfulCommands());
+        $this->assertSame($numberOfFailedCommands, $response->getNumberOfFailedCommands());
+
+        $this->assertContainsOnlyInstancesOf(CommandResponse::class, $response->getCommandResponses());
+        $this->assertCount(count($commandResponses), $response->getCommandResponses());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideResponseData(): array
+    {
+        $okCommandResponse = (object) ['status' => CommandResponse::STATUS_OK, 'message' => '', 'data' => []];
+        $failedCommandResponse = (object) ['status' => CommandResponse::STATUS_ERROR, 'message' => 'KO', 'data' => []];
+
+        return [
+            'empty response data' => [0, 0, 0, []],
+            'multiple successful commands' => [2, 2, 0, [$okCommandResponse, $okCommandResponse]],
+            'multiple failed commands' => [2, 0, 2, [$failedCommandResponse, $failedCommandResponse]],
+            'multiple failed and successful commands' => [
+                4,
+                2,
+                2,
+                [
+                    $failedCommandResponse,
+                    $okCommandResponse,
+                    $okCommandResponse,
+                    $failedCommandResponse,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideInconsistentData
+     * @test
+     */
+    public function shouldThrowExceptionWhenInconsistentDataProvided(
+        int $numberOfCommands,
+        int $numberOfSuccessfulCommands,
+        int $numberOfFailedCommands,
+        array $commandResponses,
+        string $expectedExceptionMessage
+    ): void {
+        $this->expectException(InvalidDomainModelArgumentException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        new Response($numberOfCommands, $numberOfSuccessfulCommands, $numberOfFailedCommands, $commandResponses);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideInconsistentData(): array
+    {
+        $commandResponse = (object) ['status' => CommandResponse::STATUS_OK, 'message' => '', 'data' => []];
+
+        return [
+            'numberOfCommands is more than command responses count' => [
+                5,
+                0,
+                0,
+                [],
+                'Provided numberOfCommands (5) is inconsistent with actual count of command responses (0)',
+            ],
+            'numberOfCommands is less than command responses count' => [
+                0,
+                0,
+                0,
+                [$commandResponse, $commandResponse],
+                'Provided numberOfCommands (0) is inconsistent with actual count of command responses (2)',
+            ],
+            'numberOfCommands does not match sum of successful and failed numbers' => [
+                2,
+                2,
+                1,
+                [$commandResponse, $commandResponse],
+                'Provided numberOfCommands (2) is inconsistent with provided sum of numberOfSuccessfulCommands (2)'
+                . ' and numberOfFailedCommands (1)',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Response JSON is decoded to `Response` object, which then contains array of `CommandResponses` - responses to individual commands which were send as part of request batch.

The `Response` could later maybe implement \Iterator, \ArrayAccess or maybe even \SplObjectStorage for simpler manipulation with the Command Responses. (see https://github.com/lmc-eu/matej-client-php/issues/8)

Also note the compatibility layer for plain string command responses. It will be removed right after https://jira.int.lmc.cz/browse/RAD-643 is released.