### PR TITLE
When all commands were rejected, we should still process the response

### DIFF
--- a/src/Http/Plugin/ExceptionPlugin.php
+++ b/src/Http/Plugin/ExceptionPlugin.php
@@ -30,7 +30,7 @@ final class ExceptionPlugin implements Plugin
             throw AuthorizationException::createFromRequestAndResponse($request, $response);
         }
 
-        if ($responseCode >= 400 && $responseCode < 600) {
+        if ($responseCode >= 401 && $responseCode < 600) {
             // TODO: use more specific exceptions
             throw new RequestException($response->getReasonPhrase(), $request, $response);
         }

--- a/tests/Http/Plugin/ExceptionPluginTest.php
+++ b/tests/Http/Plugin/ExceptionPluginTest.php
@@ -42,6 +42,10 @@ class ExceptionPluginTest extends TestCase
         return [
             'HTTP 200' => [StatusCodeInterface::STATUS_OK, RequestException::class],
             'HTTP 201' => [StatusCodeInterface::STATUS_CREATED, AuthorizationException::class],
+            'HTTP 400 (batch was successfully executed, but all commands were rejected)' => [
+                StatusCodeInterface::STATUS_BAD_REQUEST,
+                RequestException::class,
+            ],
         ];
     }
 
@@ -72,7 +76,6 @@ class ExceptionPluginTest extends TestCase
     public function provideErrorStatusCodes(): array
     {
         return [
-            'HTTP 400' => [StatusCodeInterface::STATUS_BAD_REQUEST, RequestException::class],
             'HTTP 401' => [StatusCodeInterface::STATUS_UNAUTHORIZED, AuthorizationException::class],
             'HTTP 404' => [StatusCodeInterface::STATUS_NOT_FOUND, RequestException::class],
             'HTTP 500' => [StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR, RequestException::class],

--- a/tests/Http/Plugin/ExceptionPluginTest.php
+++ b/tests/Http/Plugin/ExceptionPluginTest.php
@@ -40,11 +40,10 @@ class ExceptionPluginTest extends TestCase
     public function provideSuccessStatusCodes(): array
     {
         return [
-            'HTTP 200' => [StatusCodeInterface::STATUS_OK, RequestException::class],
-            'HTTP 201' => [StatusCodeInterface::STATUS_CREATED, AuthorizationException::class],
+            'HTTP 200' => [StatusCodeInterface::STATUS_OK],
+            'HTTP 201' => [StatusCodeInterface::STATUS_CREATED],
             'HTTP 400 (batch was successfully executed, but all commands were rejected)' => [
                 StatusCodeInterface::STATUS_BAD_REQUEST,
-                RequestException::class,
             ],
         ];
     }


### PR DESCRIPTION
According to Matej API docs:
> Matej returns 400 Client Error when all commands are rejected.

So from the API client point-of-view HTTP 400 is a "proper" response, which still should be processed and its data should be returned to the application (not causing an exception). 