### PR TITLE
Request manager to handle HTTP layer

### DIFF
--- a/src/Http/RequestManager.php
+++ b/src/Http/RequestManager.php
@@ -1,0 +1,126 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Http;
+
+use Http\Client\Common\Plugin\AuthenticationPlugin;
+use Http\Client\Common\PluginClient;
+use Http\Client\HttpClient;
+use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\MessageFactoryDiscovery;
+use Http\Message\MessageFactory;
+use Lmc\Matej\Http\Plugin\ExceptionPlugin;
+use Lmc\Matej\Model\Request;
+use Lmc\Matej\Model\Response;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Encapsulates HTTP layer, ie. request/response handling.
+ * This class should not be typically used directly - its supposed to be called internally from `Matej` class.
+ */
+class RequestManager
+{
+    /** @var string */
+    protected $accountId;
+    /** @var string */
+    protected $apiKey;
+    /** @var HttpClient */
+    protected $httpClient;
+    /** @var MessageFactory */
+    protected $messageFactory;
+    /** @var ResponseDecoderInterface */
+    protected $responseDecoder;
+
+    public function __construct(string $accountId, string $apiKey)
+    {
+        $this->accountId = $accountId;
+        $this->apiKey = $apiKey;
+    }
+
+    public function sendRequest(Request $request): Response
+    {
+        $httpRequest = $this->createHttpRequestFromMatejRequest($request);
+
+        $client = $this->createConfiguredHttpClient();
+
+        $httpResponse = $client->sendRequest($httpRequest);
+
+        return $this->getResponseDecoder()->decode($httpResponse);
+    }
+
+    /** @codeCoverageIgnore */
+    public function setHttpClient(HttpClient $httpClient): void
+    {
+        $this->httpClient = $httpClient;
+    }
+
+    /** @codeCoverageIgnore */
+    public function setMessageFactory(MessageFactory $messageFactory): void
+    {
+        $this->messageFactory = $messageFactory;
+    }
+
+    /** @codeCoverageIgnore */
+    public function setResponseDecoder(ResponseDecoderInterface $responseDecoder): void
+    {
+        $this->responseDecoder = $responseDecoder;
+    }
+
+    protected function getHttpClient(): HttpClient
+    {
+        if ($this->httpClient === null) {
+            // @codeCoverageIgnoreStart
+            $this->httpClient = HttpClientDiscovery::find();
+            // @codeCoverageIgnoreEnd
+        }
+
+        return $this->httpClient;
+    }
+
+    protected function getMessageFactory(): MessageFactory
+    {
+        if ($this->messageFactory === null) {
+            $this->messageFactory = MessageFactoryDiscovery::find();
+        }
+
+        return $this->messageFactory;
+    }
+
+    protected function getResponseDecoder(): ResponseDecoderInterface
+    {
+        if ($this->responseDecoder === null) {
+            $this->responseDecoder = new ResponseDecoder();
+        }
+
+        return $this->responseDecoder;
+    }
+
+    protected function createConfiguredHttpClient(): HttpClient
+    {
+        return new PluginClient(
+            $this->getHttpClient(),
+            [
+                new AuthenticationPlugin(new HmacAuthentication($this->apiKey)),
+                new ExceptionPlugin(),
+            ]
+        );
+    }
+
+    protected function createHttpRequestFromMatejRequest(Request $request): RequestInterface
+    {
+        $requestBody = json_encode($request->getData());
+        $uri = $this->buildBaseUrl() . $request->getPath();
+
+        return $this->getMessageFactory()
+            ->createRequest(
+                $request->getMethod(),
+                $uri,
+                ['Content-Type' => 'application/json'],
+                $requestBody
+            );
+    }
+
+    protected function buildBaseUrl(): string
+    {
+        return sprintf('https://%s.matej.lmc.cz', $this->accountId);
+    }
+}

--- a/src/Http/ResponseDecoderInterface.php
+++ b/src/Http/ResponseDecoderInterface.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Lmc\Matej\Http;
 

--- a/src/Model/Request.php
+++ b/src/Model/Request.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model;
+
+/**
+ * Represents request to Matej prepared to be executed by `RequestManager`.
+ */
+class Request
+{
+    /** @var string */
+    private $path;
+    /** @var string */
+    private $method;
+    /** @var array */
+    private $data;
+
+    public function __construct(string $path, string $method, array $data)
+    {
+        $this->path = $path;
+        $this->method = $method;
+        $this->data = $data;
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+}

--- a/tests/Exception/AuthorizationExceptionTest.php
+++ b/tests/Exception/AuthorizationExceptionTest.php
@@ -1,12 +1,11 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Lmc\Matej\Exception;
 
 use Fig\Http\Message\StatusCodeInterface;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use PHPUnit\Framework\TestCase;
+use Lmc\Matej\TestCase;
 
 class AuthorizationExceptionTest extends TestCase
 {

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -5,7 +5,7 @@ namespace Lmc\Matej\Exception;
 use Fig\Http\Message\StatusCodeInterface;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use PHPUnit\Framework\TestCase;
+use Lmc\Matej\TestCase;
 
 class RequestExceptionTest extends TestCase
 {

--- a/tests/Http/HmacAuthenticationTest.php
+++ b/tests/Http/HmacAuthenticationTest.php
@@ -2,8 +2,8 @@
 
 namespace Lmc\Matej\Http;
 
+use Lmc\Matej\TestCase;
 use phpmock\phpunit\PHPMock;
-use PHPUnit\Framework\TestCase;
 
 class HmacAuthenticationTest extends TestCase
 {

--- a/tests/Http/Plugin/ExceptionPluginTest.php
+++ b/tests/Http/Plugin/ExceptionPluginTest.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Lmc\Matej\Http\Plugin;
 

--- a/tests/Http/RequestManagerTest.php
+++ b/tests/Http/RequestManagerTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Http;
+
+use Fig\Http\Message\RequestMethodInterface;
+use Http\Mock\Client;
+use Lmc\Matej\Model\Request;
+use Lmc\Matej\Model\Response;
+use Lmc\Matej\TestCase;
+
+/**
+ * @covers \Lmc\Matej\Http\RequestManager
+ */
+class RequestManagerTest extends TestCase
+{
+    /**
+     * Test sending request and decoding response - but isolated from the real HTTP using Http\Mock\Client.
+     * However all other RequestManager dependencies are real, making this partially integration test.
+     *
+     * @test
+     */
+    public function shouldSendAndDecodeRequest(): void
+    {
+        $dummyHttpResponse = $this->createJsonResponseFromFile(__DIR__ . '/Fixtures/response-one-successful-command.json');
+
+        $mockClient = new Client();
+        $mockClient->addResponse($dummyHttpResponse);
+
+        $requestManager = new RequestManager('account-id', 'api-key');
+        $requestManager->setHttpClient($mockClient);
+
+        $request = new Request(
+            '/foo/endpoint',
+            RequestMethodInterface::METHOD_PUT,
+            ['foo' => 'bar', 'list' => ['lorem' => 'ipsum', 'dolor' => 333]]
+        );
+
+        $matejResponse = $requestManager->sendRequest($request);
+
+        // Request should be decoded to Matej Response; decoding itself is comprehensively tested in ResponseDecoderTest
+        $this->assertInstanceOf(Response::class, $matejResponse);
+
+        // Assert properties of the send request
+        $recordedRequests = $mockClient->getRequests();
+        $this->assertCount(1, $recordedRequests);
+        $this->assertRegExp(
+            '~https\://account\-id\.matej\.lmc\.cz/foo/endpoint\?hmac_timestamp\=[0-9]+&hmac_sign\=[[:alnum:]]~',
+            $recordedRequests[0]->getUri()->__toString()
+        );
+        $this->assertSame(RequestMethodInterface::METHOD_PUT, $recordedRequests[0]->getMethod());
+        $this->assertJsonStringEqualsJsonString(
+            '{"foo":"bar","list":{"lorem":"ipsum","dolor":333}}',
+            $recordedRequests[0]->getBody()->__toString()
+        );
+        $this->assertSame(['application/json'], $recordedRequests[0]->getHeader('Content-Type'));
+    }
+}

--- a/tests/Http/ResponseDecoderTest.php
+++ b/tests/Http/ResponseDecoderTest.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Lmc\Matej\Http;
 
@@ -7,8 +6,7 @@ use Fig\Http\Message\StatusCodeInterface;
 use GuzzleHttp\Psr7\Response;
 use Lmc\Matej\Exception\ResponseDecodingException;
 use Lmc\Matej\Model\CommandResponse;
-use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\ResponseInterface;
+use Lmc\Matej\TestCase;
 
 class ResponseDecoderTest extends TestCase
 {
@@ -82,13 +80,5 @@ class ResponseDecoderTest extends TestCase
         $this->expectExceptionMessage('Error decoding Matej response: required data missing.');
         $this->expectExceptionMessage('"invalid": [],');
         $this->decoder->decode($response);
-    }
-
-    private function createJsonResponseFromFile(string $fileName): ResponseInterface
-    {
-        $jsonData = file_get_contents($fileName);
-        $response = new Response(StatusCodeInterface::STATUS_OK, ['Content-Type' => 'application/json'], $jsonData);
-
-        return $response;
     }
 }

--- a/tests/Model/CommandResponseTest.php
+++ b/tests/Model/CommandResponseTest.php
@@ -1,10 +1,9 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Lmc\Matej\Model;
 
 use Lmc\Matej\Exception\InvalidDomainModelArgumentException;
-use PHPUnit\Framework\TestCase;
+use Lmc\Matej\TestCase;
 
 class CommandResponseTest extends TestCase
 {

--- a/tests/Model/RequestTest.php
+++ b/tests/Model/RequestTest.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model;
+
+use Fig\Http\Message\RequestMethodInterface;
+use Lmc\Matej\TestCase;
+
+class RequestTest extends TestCase
+{
+    /** @test */
+    public function shouldBeInstantiable(): void
+    {
+        $path = '/foo/endpoint';
+        $method = RequestMethodInterface::METHOD_GET;
+        $data = ['foo' => 'bar', ['lorem' => 'ipsum']];
+
+        $request = new Request($path, $method, $data);
+
+        $this->assertInstanceOf(Request::class, $request);
+        $this->assertSame($path, $request->getPath());
+        $this->assertSame($method, $request->getMethod());
+        $this->assertSame($data, $request->getData());
+    }
+}

--- a/tests/Model/ResponseTest.php
+++ b/tests/Model/ResponseTest.php
@@ -1,10 +1,9 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Lmc\Matej\Model;
 
 use Lmc\Matej\Exception\InvalidDomainModelArgumentException;
-use PHPUnit\Framework\TestCase;
+use Lmc\Matej\TestCase;
 
 class ResponseTest extends TestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej;
+
+use Fig\Http\Message\StatusCodeInterface;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\ResponseInterface;
+
+class TestCase extends \PHPUnit\Framework\TestCase
+{
+    protected function createJsonResponseFromFile(string $fileName): ResponseInterface
+    {
+        $jsonData = file_get_contents($fileName);
+        $response = new Response(StatusCodeInterface::STATUS_OK, ['Content-Type' => 'application/json'], $jsonData);
+
+        return $response;
+    }
+}


### PR DESCRIPTION
`RequestManager` takes prepared instance of `Lmc\Matej\Model\Request`, executes it (adding HmacAuth etc. to the HttpClient) it and processes the Http response to internal domain model (`Lmc\Matej\Model\Response`).

Usage example:
```php
$matejRequest = new \Lmc\Matej\Model\Request('/item-properties', 'PUT', [[...], [...]]);

$matejResponse = $requestManager->sendRequest($matejRequest);

// => instance of Lmc\Matej\Model\Response
```

This is again part of API client internal HTTP layer. The example above *will not* be used directly in application code - the Request instance will ve prepared using builder objects (which will be done soon).
