### PR TITLE
Commands to setup and update database items

### DIFF
--- a/src/Model/Command/AbstractCommand.php
+++ b/src/Model/Command/AbstractCommand.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model\Command;
+
+abstract class AbstractCommand implements \JsonSerializable
+{
+    /**
+     * Get command type identifier. Must be one of those defined by Matej API schema.
+     */
+    abstract protected function getCommandType(): string;
+
+    /**
+     * Get data content of the command. Must follow the format defined by Matej API schema.
+     */
+    abstract protected function getCommandParameters(): array;
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'type' => $this->getCommandType(),
+            'parameters' => $this->getCommandParameters(),
+        ];
+    }
+}

--- a/src/Model/Command/ItemProperty.php
+++ b/src/Model/Command/ItemProperty.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model\Command;
+
+/**
+ * Command to save different item content properties to Matej.
+ */
+class ItemProperty extends AbstractCommand
+{
+    /** @var string */
+    private $itemId;
+    /** @var array */
+    private $properties;
+
+    private function __construct(string $itemId, array $properties)
+    {
+        // TODO: assert itemId format
+
+        $this->itemId = $itemId;
+        $this->properties = $properties;
+    }
+
+    public static function create(string $itemId, array $properties = []): self
+    {
+        return new static($itemId, $properties);
+    }
+
+    protected function getCommandType(): string
+    {
+        return 'item-properties';
+    }
+
+    protected function getCommandParameters(): array
+    {
+        $parameters = $this->properties;
+
+        $parameters['item_id'] = $this->itemId;
+
+        return $parameters;
+    }
+}

--- a/src/Model/Command/ItemPropertySetup.php
+++ b/src/Model/Command/ItemPropertySetup.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model\Command;
+
+/**
+ * Command to add or delete item property in the database.
+ */
+class ItemPropertySetup extends AbstractCommand
+{
+    const PROPERTY_TYPE_INT = 'int';
+    const PROPERTY_TYPE_DOUBLE = 'double';
+    const PROPERTY_TYPE_STRING = 'string';
+    const PROPERTY_TYPE_BOOLEAN = 'boolean';
+    const PROPERTY_TYPE_TIMESTAMP = 'timestamp';
+    const PROPERTY_TYPE_SET = 'set';
+
+    /** @var string */
+    private $propertyName;
+    /** @var string */
+    private $propertyType;
+
+    private function __construct(string $propertyName, string $propertyType)
+    {
+        // TODO: assert propertyName format
+        // TODO: assert propertyType is one of PROPERTY_TYPE_*
+
+        $this->propertyName = $propertyName;
+        $this->propertyType = $propertyType;
+    }
+
+    public static function int(string $propertyName): self
+    {
+        return new static($propertyName, self::PROPERTY_TYPE_INT);
+    }
+
+    public static function double(string $propertyName): self
+    {
+        return new static($propertyName, self::PROPERTY_TYPE_DOUBLE);
+    }
+
+    public static function string(string $propertyName): self
+    {
+        return new static($propertyName, self::PROPERTY_TYPE_STRING);
+    }
+
+    public static function boolean(string $propertyName): self
+    {
+        return new static($propertyName, self::PROPERTY_TYPE_BOOLEAN);
+    }
+
+    public static function timestamp(string $propertyName): self
+    {
+        return new static($propertyName, self::PROPERTY_TYPE_TIMESTAMP);
+    }
+
+    public static function set(string $propertyName): self
+    {
+        return new static($propertyName, self::PROPERTY_TYPE_SET);
+    }
+
+    protected function getCommandType(): string
+    {
+        return 'item-properties-setup';
+    }
+
+    protected function getCommandParameters(): array
+    {
+        return [
+            'property_name' => $this->propertyName,
+            'property_type' => $this->propertyType,
+        ];
+    }
+}

--- a/tests/Model/Command/ItemPropertySetupTest.php
+++ b/tests/Model/Command/ItemPropertySetupTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model\Command;
+
+use PHPUnit\Framework\TestCase;
+
+class ItemPropertySetupTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider provideConstructorName
+     */
+    public function shouldBeInstantiableViaNamedConstructors(
+        string $constructorName,
+        string $expectedPropertyType
+    ): void {
+        $propertyName = 'examplePropertyName';
+
+        /** @var ItemPropertySetup $command */
+        $command = forward_static_call([ItemPropertySetup::class, $constructorName], $propertyName);
+
+        $this->assertInstanceOf(ItemPropertySetup::class, $command);
+        $this->assertSame(
+            [
+                'type' => 'item-properties-setup',
+                'parameters' => [
+                    'property_name' => 'examplePropertyName',
+                    'property_type' => $expectedPropertyType,
+                ],
+            ],
+            $command->jsonSerialize()
+        );
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideConstructorName(): array
+    {
+        return [
+            ['int', ItemPropertySetup::PROPERTY_TYPE_INT],
+            ['double', ItemPropertySetup::PROPERTY_TYPE_DOUBLE],
+            ['string', ItemPropertySetup::PROPERTY_TYPE_STRING],
+            ['boolean', ItemPropertySetup::PROPERTY_TYPE_BOOLEAN],
+            ['timestamp', ItemPropertySetup::PROPERTY_TYPE_TIMESTAMP],
+            ['set', ItemPropertySetup::PROPERTY_TYPE_SET],
+        ];
+    }
+}

--- a/tests/Model/Command/ItemPropertyTest.php
+++ b/tests/Model/Command/ItemPropertyTest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model\Command;
+
+use PHPUnit\Framework\TestCase;
+
+class ItemPropertyTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider provideProperties
+     */
+    public function shouldBeInstantiableViaNamedConstructor(array $properties, array $expectedParameters): void
+    {
+        $command = ItemProperty::create('exampleItemId', $properties);
+
+        $this->assertInstanceOf(ItemProperty::class, $command);
+        $this->assertSame(
+            [
+                'type' => 'item-properties',
+                'parameters' => $expectedParameters,
+            ],
+            $command->jsonSerialize()
+        );
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideProperties(): array
+    {
+        return [
+            'No item properties' => [[], ['item_id' => 'exampleItemId']],
+            'One item property' => [['date' => 1510756952], ['date' => 1510756952, 'item_id' => 'exampleItemId']],
+            'Multiple item properties' => [
+                ['item1' => 'value1', 'item2' => 'value2'],
+                ['item1' => 'value1', 'item2' => 'value2', 'item_id' => 'exampleItemId'],
+            ],
+            'Should not allow to override item_id' => [
+                ['item_id' => 'customItemId'],
+                ['item_id' => 'exampleItemId'],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Matej endpoints accepts set of specific Commands.

They will be used when building request to Matej. Unlike previous PRs, **these classes will actually be used by the end application**, so make sure their API fits your needs.

For example the final usage from application point of view will be like:
```php
// to setup new item properties in the database
$response = $matej->request()
    ->itemPropertiesSetup()
    ->addProperty(ItemPropertySetup::timestamp('valid_from'))
    ->addProperty(ItemPropertySetup::string('title'))
    ->send();
```

Or
```php
// to send events
$response = $matej->request()
    ->events()
    ->addProperty(ItemProperty::create('.... adId', ['valid_to' => 1510756958])) // update properties of item (ad)
    ->addInteraction('adId', 'userId', 'interactionType', ...) // to submit interactions - not part of this PR
    ->send();
```

The `request()` method, `itemPropertiesSetup()` and `send()` etc. will be part of some future PR - this PR is just about first two Command types.