### PR TITLE
🏗 Request builder for Item Properties Setup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         ],
         "analyze": [
             "vendor/bin/php-cs-fixer fix -vvv --diff --dry-run --ansi",
-            "vendor/bin/phpstan.phar analyze ./src ./tests --level 7 --ansi"
+            "vendor/bin/phpstan.phar analyze ./src ./tests -c phpstan.neon --level 7 --ansi"
         ]
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,3 @@
+parameters:
+	ignoreErrors:
+		- '#expects .*, PHPUnit_Framework_MockObject_MockObject given#'

--- a/src/Exception/InvalidDomainModelArgumentException.php
+++ b/src/Exception/InvalidDomainModelArgumentException.php
@@ -5,7 +5,7 @@ namespace Lmc\Matej\Exception;
 /**
  * Exception thrown when invalid argument is passed while creating domain model.
  */
-class InvalidDomainModelArgumentException extends AbstractMatejException
+class InvalidDomainModelArgumentException extends LogicException
 {
     public static function forInconsistentNumberOfCommands(
         int $numberOfCommands,

--- a/src/Exception/LogicException.php
+++ b/src/Exception/LogicException.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Exception;
+
+/**
+ * Exception represents error in the program logic.
+ */
+class LogicException extends AbstractMatejException
+{
+}

--- a/src/RequestBuilder/AbstractRequestBuilder.php
+++ b/src/RequestBuilder/AbstractRequestBuilder.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\RequestBuilder;
+
+use Lmc\Matej\Exception\LogicException;
+use Lmc\Matej\Http\RequestManager;
+use Lmc\Matej\Model\Request;
+use Lmc\Matej\Model\Response;
+
+/**
+ * Request builders provides methods for simple and type-safe assembly of request to specific Matej endpoint.
+ *
+ * If `RequestManager` is injected to the builder via `setRequestManager()`, the request could be executed right from
+ * the builder using `send()` method.
+ */
+abstract class AbstractRequestBuilder
+{
+    /** @var RequestManager */
+    protected $requestManager;
+
+    /**
+     * Use Commands and other settings which were passed to this builder object to build instance of
+     * Lmc\Matej\Model\Request.
+     */
+    abstract public function build(): Request;
+
+    /**
+     * If instance of RequestManager is injected to this builder object, you can build and send the request directly
+     * via send() method of the builder itself.
+     */
+    public function setRequestManager(RequestManager $requestManager): self
+    {
+        $this->requestManager = $requestManager;
+
+        return $this;
+    }
+
+    public function send(): Response
+    {
+        $this->assertRequestManagerIsAvailable();
+
+        return $this->requestManager->sendRequest($this->build());
+    }
+
+    private function assertRequestManagerIsAvailable(): void
+    {
+        if ($this->requestManager === null) {
+            throw new LogicException(
+                'Instance of RequestManager must be set to request builder via setRequestManager() before'
+                . ' calling send()'
+            );
+        }
+    }
+}

--- a/src/RequestBuilder/ItemPropertiesSetupRequestBuilder.php
+++ b/src/RequestBuilder/ItemPropertiesSetupRequestBuilder.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\RequestBuilder;
+
+use Fig\Http\Message\RequestMethodInterface;
+use Lmc\Matej\Exception\LogicException;
+use Lmc\Matej\Model\Command\ItemPropertySetup;
+use Lmc\Matej\Model\Request;
+
+class ItemPropertiesSetupRequestBuilder extends AbstractRequestBuilder
+{
+    protected const ENDPOINT_PATH = '/item-properties';
+
+    /** @var ItemPropertySetup[] */
+    protected $commands = [];
+    /** @var bool */
+    protected $shouldDelete = false;
+
+    /**
+     * @param bool $shouldDelete Should the request delete item properties instead of creating new?
+     */
+    public function __construct(bool $shouldDelete = false)
+    {
+        $this->shouldDelete = $shouldDelete;
+    }
+
+    public function addProperty(ItemPropertySetup $itemPropertySetup): self
+    {
+        $this->commands[] = $itemPropertySetup;
+
+        return $this;
+    }
+
+    /**
+     * @param ItemPropertySetup[] $itemPropertiesSetup
+     * @return self
+     */
+    public function addProperties(array $itemPropertiesSetup): self
+    {
+        foreach ($itemPropertiesSetup as $itemPropertySetup) {
+            $this->addProperty($itemPropertySetup);
+        }
+
+        return $this;
+    }
+
+    public function build(): Request
+    {
+        if (empty($this->commands)) {
+            throw new LogicException(
+                'At least one ItemPropertySetup command must be added to the builder before sending the request'
+            );
+        }
+
+        $method = $this->shouldDelete ? RequestMethodInterface::METHOD_DELETE : RequestMethodInterface::METHOD_PUT;
+
+        return new Request(self::ENDPOINT_PATH, $method, $this->commands);
+    }
+}

--- a/src/RequestBuilder/RequestBuilderFactory.php
+++ b/src/RequestBuilder/RequestBuilderFactory.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\RequestBuilder;
+
+use Lmc\Matej\Http\RequestManager;
+
+/**
+ * Factory to create concrete RequestBuilder which helps you to create request for each Matej API
+ */
+class RequestBuilderFactory
+{
+    /** @var RequestManager */
+    private $requestManager;
+
+    public function __construct(RequestManager $requestManager)
+    {
+        $this->requestManager = $requestManager;
+    }
+
+    /**
+     * Define new properties into the database. Those properties will be created and subsequently accepted by Matej.
+     */
+    public function setupItemProperties(): ItemPropertiesSetupRequestBuilder
+    {
+        return $this->createConfiguredBuilder(ItemPropertiesSetupRequestBuilder::class);
+    }
+
+    /**
+     * Added item properties will be IRREVERSIBLY removed from all items in the database and the item property will
+     * from now be rejected by Matej.
+     */
+    public function deleteItemProperties(): ItemPropertiesSetupRequestBuilder
+    {
+        return $this->createConfiguredBuilder(ItemPropertiesSetupRequestBuilder::class, $shouldDelete = true);
+    }
+
+    // TODO: builders for other endpoints
+
+    /**
+     * @param string $builderClass
+     * @param array ...$args
+     * @return mixed
+     */
+    private function createConfiguredBuilder(string $builderClass, ...$args)
+    {
+        /** @var AbstractRequestBuilder $requestBuilder */
+        $requestBuilder = new $builderClass(...$args);
+
+        $requestBuilder->setRequestManager($this->requestManager);
+
+        return $requestBuilder;
+    }
+}

--- a/tests/RequestBuilder/ItemPropertiesSetupRequestBuilderTest.php
+++ b/tests/RequestBuilder/ItemPropertiesSetupRequestBuilderTest.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\RequestBuilder;
+
+use Fig\Http\Message\RequestMethodInterface;
+use Lmc\Matej\Exception\LogicException;
+use Lmc\Matej\Http\RequestManager;
+use Lmc\Matej\Model\Command\ItemPropertySetup;
+use Lmc\Matej\Model\Request;
+use Lmc\Matej\Model\Response;
+use PHPUnit\Framework\TestCase;
+
+class ItemPropertiesSetupRequestBuilderTest extends TestCase
+{
+    /** @test */
+    public function shouldThrowExceptionWhenBuildingEmptyCommands(): void
+    {
+        $builder = new ItemPropertiesSetupRequestBuilder();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('At least one ItemPropertySetup command must be added to the builder');
+        $builder->build();
+    }
+
+    /**
+     * @test
+     * @dataProvider provideBuilderVariants
+     */
+    public function shouldBuildRequestWithCommands(bool $shouldDelete, string $expectedMethod): void
+    {
+        $builder = new ItemPropertiesSetupRequestBuilder($shouldDelete);
+
+        $command1 = ItemPropertySetup::timestamp('property1');
+        $command2 = ItemPropertySetup::string('property2');
+        $command3 = ItemPropertySetup::string('property3');
+
+        $builder->addProperty($command1);
+        $builder->addProperties([$command2, $command3]);
+
+        $request = $builder->build();
+
+        $this->assertInstanceOf(Request::class, $request);
+        $this->assertSame($expectedMethod, $request->getMethod());
+        $this->assertSame('/item-properties', $request->getPath());
+        $this->assertContainsOnlyInstancesOf(ItemPropertySetup::class, $request->getData());
+        $this->assertSame($command1, $request->getData()[0]);
+        $this->assertSame($command2, $request->getData()[1]);
+        $this->assertSame($command3, $request->getData()[2]);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideBuilderVariants(): array
+    {
+        return [
+            'builder to create item properties' => [false, RequestMethodInterface::METHOD_PUT],
+            'builder to delete item properties' => [true, RequestMethodInterface::METHOD_DELETE],
+        ];
+    }
+
+    /** @test */
+    public function shouldThrowExceptionWhenSendingCommandsWithoutRequestManager(): void
+    {
+        $builder = new ItemPropertiesSetupRequestBuilder();
+
+        $builder->addProperty(ItemPropertySetup::timestamp('property1'));
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Instance of RequestManager must be set to request builder');
+        $builder->send();
+    }
+
+    /** @test */
+    public function shouldSendRequestViaRequestManager(): void
+    {
+        $requestManagerMock = $this->createMock(RequestManager::class);
+        $requestManagerMock->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->isInstanceOf(Request::class))
+            ->willReturn(new Response(0, 0, 0, 0));
+
+        $builder = new ItemPropertiesSetupRequestBuilder();
+        $builder->setRequestManager($requestManagerMock);
+
+        $builder->addProperty(ItemPropertySetup::timestamp('property1'));
+
+        $builder->send();
+    }
+}

--- a/tests/RequestBuilder/RequestBuilderFactoryTest.php
+++ b/tests/RequestBuilder/RequestBuilderFactoryTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\RequestBuilder;
+
+use Lmc\Matej\Http\RequestManager;
+use Lmc\Matej\Model\Command\ItemPropertySetup;
+use Lmc\Matej\Model\Request;
+use Lmc\Matej\Model\Response;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lmc\Matej\RequestBuilder\RequestBuilderFactory
+ */
+class RequestBuilderFactoryTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider provideBuilderMethods
+     */
+    public function shouldInstantiateBuilderToBuildAndSendRequest(
+        string $factoryMethod,
+        string $expectedBuilderClass,
+        \Closure $minimalBuilderInit
+    ): void {
+        $requestManagerMock = $this->createMock(RequestManager::class);
+        $requestManagerMock->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->isInstanceOf(Request::class))
+            ->willReturn(new Response(0, 0, 0, 0));
+
+        $factory = new RequestBuilderFactory($requestManagerMock);
+
+        /** @var AbstractRequestBuilder $builder */
+        $builder = $factory->$factoryMethod();
+
+        // Builders may require some minimal setup to be able to execute the build() method
+        $minimalBuilderInit($builder);
+
+        $this->assertInstanceOf($expectedBuilderClass, $builder);
+        $this->assertInstanceOf(Request::class, $builder->build());
+
+        // Make sure the builder has been properly configured and it can execute send() via RequestManager mock:
+        $this->assertInstanceOf(Response::class, $builder->send());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideBuilderMethods(): array
+    {
+        $itemPropertiesSetupInit = function (ItemPropertiesSetupRequestBuilder $builder): void {
+            $builder->addProperty(ItemPropertySetup::timestamp('valid_from'));
+        };
+
+        return [
+            ['setupItemProperties', ItemPropertiesSetupRequestBuilder::class, $itemPropertiesSetupInit],
+            ['deleteItemProperties', ItemPropertiesSetupRequestBuilder::class, $itemPropertiesSetupInit],
+        ];
+    }
+}


### PR DESCRIPTION
This is finally the first part of the facade layer, which will be used by the end application.

(Names of the builder methods may change later - any suggestions?).

Example usage for this builder and builder factory (this is from the end application point of view):

```php
$matej = new Matej('foo', 'apikey');

$response = $matej->request() // this actually returns the builder factory (method is not yet implemented)
    ->itemPropertiesSetup() // this is method of the builder factory, which returns the concrete builder
    ->addProperties([ItemPropertySetup::timestamp('valid_from'), ItemPropertySetup::string('title')]) // example of add multiple commands at once
    ->addProperty(ItemPropertySetup::timestamp('valid_to')) // add just one command
    ->requestWillDelete() // when this method is added, the requets will actually drop the item properties passed via addProperty(ies) method from the database
    ->send();
```

Thoughts, comments? PR with builder for Event endpoint will follow soon.