### PR TITLE
Builder for events request

### DIFF
--- a/src/RequestBuilder/EventsRequestBuilder.php
+++ b/src/RequestBuilder/EventsRequestBuilder.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\RequestBuilder;
+
+use Fig\Http\Message\RequestMethodInterface;
+use Lmc\Matej\Exception\LogicException;
+use Lmc\Matej\Model\Command\AbstractCommand;
+use Lmc\Matej\Model\Command\ItemProperty;
+use Lmc\Matej\Model\Request;
+
+class EventsRequestBuilder extends AbstractRequestBuilder
+{
+    protected const ENDPOINT_PATH = '/events';
+
+    /** @var AbstractCommand[] */
+    protected $commands = [];
+
+    public function addItemProperty(ItemProperty $itemProperty): self
+    {
+        $this->commands[] = $itemProperty;
+
+        return $this;
+    }
+
+    /**
+     * @param ItemProperty[] $itemProperties
+     * @return self
+     */
+    public function addItemProperties(array $itemProperties): self
+    {
+        foreach ($itemProperties as $itemProperty) {
+            $this->addItemProperty($itemProperty);
+        }
+
+        return $this;
+    }
+
+    // TODO: methods to addInteraction(s) and addUserMerge(s)
+
+    public function build(): Request
+    {
+        if (empty($this->commands)) {
+            throw new LogicException('At least one command must be added to the builder before sending the request');
+        }
+
+        return new Request(self::ENDPOINT_PATH, RequestMethodInterface::METHOD_POST, $this->commands);
+    }
+}

--- a/src/RequestBuilder/RequestBuilderFactory.php
+++ b/src/RequestBuilder/RequestBuilderFactory.php
@@ -34,6 +34,11 @@ class RequestBuilderFactory
         return $this->createConfiguredBuilder(ItemPropertiesSetupRequestBuilder::class, $shouldDelete = true);
     }
 
+    public function events(): EventsRequestBuilder
+    {
+        return $this->createConfiguredBuilder(EventsRequestBuilder::class);
+    }
+
     // TODO: builders for other endpoints
 
     /**

--- a/tests/RequestBuilder/EventsRequestBuilderTest.php
+++ b/tests/RequestBuilder/EventsRequestBuilderTest.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\RequestBuilder;
+
+use Fig\Http\Message\RequestMethodInterface;
+use Lmc\Matej\Exception\LogicException;
+use Lmc\Matej\Http\RequestManager;
+use Lmc\Matej\Model\Command\ItemProperty;
+use Lmc\Matej\Model\Request;
+use Lmc\Matej\Model\Response;
+use PHPUnit\Framework\TestCase;
+
+class EventsRequestBuilderTest extends TestCase
+{
+    /** @test */
+    public function shouldThrowExceptionWhenBuildingEmptyCommands(): void
+    {
+        $builder = new EventsRequestBuilder();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('At least one command must be added to the builder');
+        $builder->build();
+    }
+
+    /** @test */
+    public function shouldBuildRequestWithCommands(): void
+    {
+        $builder = new EventsRequestBuilder();
+
+        $command1 = ItemProperty::create('id-1', ['key1' => 'value1']);
+        $command2 = ItemProperty::create('id-2', ['key1' => 'value3']);
+        $command3 = ItemProperty::create('id-3', ['key1' => 'value3']);
+
+        $builder->addItemProperty($command1);
+        $builder->addItemProperties([$command2, $command3]);
+
+        $request = $builder->build();
+
+        $this->assertInstanceOf(Request::class, $request);
+        $this->assertSame(RequestMethodInterface::METHOD_POST, $request->getMethod());
+        $this->assertSame('/events', $request->getPath());
+        $this->assertContainsOnlyInstancesOf(ItemProperty::class, $request->getData());
+        $this->assertSame($command1, $request->getData()[0]);
+        $this->assertSame($command2, $request->getData()[1]);
+        $this->assertSame($command3, $request->getData()[2]);
+    }
+
+    /** @test */
+    public function shouldThrowExceptionWhenSendingCommandsWithoutRequestManager(): void
+    {
+        $builder = new EventsRequestBuilder();
+
+        $builder->addItemProperty(ItemProperty::create('id-1', ['key1' => 'value1']));
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Instance of RequestManager must be set to request builder');
+        $builder->send();
+    }
+
+    /** @test */
+    public function shouldSendRequestViaRequestManager(): void
+    {
+        $requestManagerMock = $this->createMock(RequestManager::class);
+        $requestManagerMock->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->isInstanceOf(Request::class))
+            ->willReturn(new Response(0, 0, 0, 0));
+
+        $builder = new EventsRequestBuilder();
+        $builder->setRequestManager($requestManagerMock);
+
+        $builder->addItemProperty(ItemProperty::create('id-1', ['key1' => 'value1']));
+
+        $builder->send();
+    }
+}

--- a/tests/RequestBuilder/RequestBuilderFactoryTest.php
+++ b/tests/RequestBuilder/RequestBuilderFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Lmc\Matej\RequestBuilder;
 
 use Lmc\Matej\Http\RequestManager;
+use Lmc\Matej\Model\Command\ItemProperty;
 use Lmc\Matej\Model\Command\ItemPropertySetup;
 use Lmc\Matej\Model\Request;
 use Lmc\Matej\Model\Response;
@@ -52,9 +53,14 @@ class RequestBuilderFactoryTest extends TestCase
             $builder->addProperty(ItemPropertySetup::timestamp('valid_from'));
         };
 
+        $eventInit = function (EventsRequestBuilder $builder): void {
+            $builder->addItemProperty(ItemProperty::create('item-id', []));
+        };
+
         return [
             ['setupItemProperties', ItemPropertiesSetupRequestBuilder::class, $itemPropertiesSetupInit],
             ['deleteItemProperties', ItemPropertiesSetupRequestBuilder::class, $itemPropertiesSetupInit],
+            ['events', EventsRequestBuilder::class, $eventInit],
         ];
     }
 }


### PR DESCRIPTION
Only item-property support is implemented in the builder (interactions and user merges are missing so far - will be implemented later).

Example usage is similar as in https://github.com/lmc-eu/matej-client-php/pull/15:
```php
$matej = new Matej('foo', 'apikey');

$response = $matej->request() // not yet implemented in the Matej class
    ->events()
    ->addItemProperty(ItemProperty::create('1337', ['valid_from' => time(), 'title' => 'Title']))  // add just one command
    ->addItemProperties([
        ItemProperty::create('666', ['valid_from' => time()]),
        UserMerge::targetUserFromSourceUser('target-id', 'source-id'),  // command not yet implemented
        Interaction::view('user-id', 'item-id'),  // command not yet implemented
    ])  // add multiple commands
    ->send();

```