### PR TITLE
Create and send requests through Matej instance

### DIFF
--- a/src/Http/ResponseDecoder.php
+++ b/src/Http/ResponseDecoder.php
@@ -12,7 +12,7 @@ class ResponseDecoder implements ResponseDecoderInterface
     {
         $responseData = json_decode($httpResponse->getBody()->getContents());
 
-        if (JSON_ERROR_NONE !== json_last_error()) {
+        if (json_last_error() !== JSON_ERROR_NONE) {
             throw ResponseDecodingException::forJsonError(json_last_error_msg(), $httpResponse);
         }
 

--- a/src/Matej.php
+++ b/src/Matej.php
@@ -2,19 +2,61 @@
 
 namespace Lmc\Matej;
 
+use Http\Client\HttpClient;
+use Http\Message\MessageFactory;
+use Lmc\Matej\Http\RequestManager;
+use Lmc\Matej\Http\ResponseDecoderInterface;
+use Lmc\Matej\RequestBuilder\RequestBuilderFactory;
+
 class Matej
 {
     public const CLIENT_ID = 'php-client';
     public const VERSION = '0.0.0';
 
     /** @var string */
-    private $clientId;
+    private $accountId;
     /** @var string */
     private $apiKey;
+    /** @var RequestManager */
+    private $requestManager;
 
-    public function __construct(string $clientId, string $apiKey)
+    public function __construct(string $accountId, string $apiKey)
     {
-        $this->clientId = $clientId;
+        $this->accountId = $accountId;
         $this->apiKey = $apiKey;
+        $this->requestManager = new RequestManager($accountId, $apiKey);
+    }
+
+    public function request(): RequestBuilderFactory
+    {
+        return new RequestBuilderFactory($this->getRequestManager());
+    }
+
+    public function setHttpClient(HttpClient $client): self
+    {
+        $this->getRequestManager()->setHttpClient($client);
+
+        return $this;
+    }
+
+    /** @codeCoverageIgnore */
+    public function setHttpMessageFactory(MessageFactory $messageFactory): self
+    {
+        $this->getRequestManager()->setMessageFactory($messageFactory);
+
+        return $this;
+    }
+
+    /** @codeCoverageIgnore */
+    public function setHttpResponseDecoder(ResponseDecoderInterface $responseDecoder): self
+    {
+        $this->getRequestManager()->setResponseDecoder($responseDecoder);
+
+        return $this;
+    }
+
+    protected function getRequestManager(): RequestManager
+    {
+        return $this->requestManager;
     }
 }

--- a/tests/MatejTest.php
+++ b/tests/MatejTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej;
+
+use Http\Mock\Client;
+use Lmc\Matej\Model\Command\ItemPropertySetup;
+use Lmc\Matej\Model\CommandResponse;
+
+/**
+ * @covers \Lmc\Matej\Matej
+ */
+class MatejTest extends TestCase
+{
+    /** @test */
+    public function shouldBeInstantiable(): void
+    {
+        $matej = new Matej('accountId', 'apiKey');
+        $this->assertInstanceOf(Matej::class, $matej);
+    }
+
+    /** @test */
+    public function shouldExecuteRequestViaBuilder(): void
+    {
+        $dummyHttpResponse = $this->createJsonResponseFromFile(__DIR__ . '/Http/Fixtures/response-one-successful-command.json');
+
+        $mockClient = new Client();
+        $mockClient->addResponse($dummyHttpResponse);
+
+        $matej = new Matej('accountId', 'apiKey');
+        $matej->setHttpClient($mockClient);
+
+        $response = $matej->request()
+            ->setupItemProperties()
+            ->addProperty(ItemPropertySetup::timestamp('valid_from'))
+            ->send();
+
+        $this->assertCount(1, $mockClient->getRequests());
+        $this->assertStringStartsWith(
+            'https://accountid.matej.lmc.cz/',
+            $mockClient->getRequests()[0]->getUri()->__toString()
+        );
+
+        $this->assertSame(1, $response->getNumberOfCommands());
+        $this->assertSame(1, $response->getNumberOfSuccessfulCommands());
+        $this->assertSame(0, $response->getNumberOfSkippedCommands());
+        $this->assertSame(0, $response->getNumberOfFailedCommands());
+        $this->assertCount(1, $response->getCommandResponses());
+        $this->assertInstanceOf(CommandResponse::class, $response->getCommandResponses()[0]);
+        $this->assertSame(CommandResponse::STATUS_OK, $response->getCommandResponses()[0]->getStatus());
+    }
+}


### PR DESCRIPTION
Final piece to actually interact with Matej API through the main `Matej` object instance 🎉 .

What is possible so far:

```php
$matej = new Matej('foo', 'apikey');

// Create new item property in database:
$response = $matej->request()
    ->setupItemProperties()
    ->addProperty(ItemPropertySetup::timestamp('valid_to'))
    ->addProperty(ItemPropertySetup::string('title'))
    ->send();

// Delete item property from database:
$response = $matej->request()
    ->deleteItemProperties()
    ->addProperty(ItemPropertySetup::timestamp('valid_from'))
    ->addProperty(ItemPropertySetup::string('title'))
    ->send();

// Send item property data to database
$response = $matej->request()
    ->events()
    ->addItemProperty(ItemProperty::create('1337', ['valid_from' => time(), 'title' => 'Title']))
    ->send();

```

Other commands and builders will follow (or will have an issue for grab).