### PR TITLE
Add missing invalid commnad response status

### DIFF
--- a/src/Model/CommandResponse.php
+++ b/src/Model/CommandResponse.php
@@ -12,6 +12,7 @@ class CommandResponse
     const STATUS_OK = 'OK';
     const STATUS_ERROR = 'ERROR';
     const STATUS_SKIPPED = 'SKIPPED';
+    const STATUS_INVALID = 'INVALID';
 
     /** @var string */
     private $status;


### PR DESCRIPTION
According to docs some endpoints could return `INVALID` status.