### PR TITLE
Add first integration test case for Item Properties setup

### DIFF
--- a/src/Http/RequestManager.php
+++ b/src/Http/RequestManager.php
@@ -24,6 +24,8 @@ class RequestManager
     public const CLIENT_VERSION_HEADER = 'Matej-Client-Version';
 
     /** @var string */
+    private $baseUrl = 'https://%s.matej.lmc.cz';
+    /** @var string */
     protected $accountId;
     /** @var string */
     protected $apiKey;
@@ -67,6 +69,12 @@ class RequestManager
     public function setResponseDecoder(ResponseDecoderInterface $responseDecoder): void
     {
         $this->responseDecoder = $responseDecoder;
+    }
+
+    /** @codeCoverageIgnore */
+    public function setBaseUrl(string $baseUrl): void
+    {
+        $this->baseUrl = $baseUrl;
     }
 
     protected function getHttpClient(): HttpClient
@@ -126,7 +134,7 @@ class RequestManager
 
     protected function buildBaseUrl(): string
     {
-        return sprintf('https://%s.matej.lmc.cz', $this->accountId);
+        return sprintf($this->baseUrl, $this->accountId);
     }
 
     private function getDefaultHeaders(): array

--- a/src/Matej.php
+++ b/src/Matej.php
@@ -39,6 +39,14 @@ class Matej
         return $this;
     }
 
+    /** @internal used mainly in integration tests */
+    public function setBaseUrl($baseUrl): self
+    {
+        $this->getRequestManager()->setBaseUrl($baseUrl);
+
+        return $this;
+    }
+
     /** @codeCoverageIgnore */
     public function setHttpMessageFactory(MessageFactory $messageFactory): self
     {

--- a/tests/IntegrationTests/IntegrationTestCase.php
+++ b/tests/IntegrationTests/IntegrationTestCase.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\IntegrationTests;
+
+use Lmc\Matej\Matej;
+use Lmc\Matej\TestCase;
+
+class IntegrationTestCase extends TestCase
+{
+    /** @before */
+    protected function checkIfConfigured(): void
+    {
+        if (!getenv('MATEJ_TEST_ACCOUNTID')) {
+            $this->markTestSkipped('Environment variable MATEJ_TEST_ACCOUNTID has to be defined');
+        }
+
+        if (!getenv('MATEJ_TEST_APIKEY')) {
+            $this->markTestSkipped('Environment variable MATEJ_TEST_APIKEY has to be defined');
+        }
+    }
+
+    protected function createMatejInstance(): Matej
+    {
+        $instance = new Matej(getenv('MATEJ_TEST_ACCOUNTID'), getenv('MATEJ_TEST_APIKEY'));
+
+        if ($baseUrl = getenv('MATEJ_TEST_BASE_URL')) { // intentional assignment
+            $instance->setBaseUrl($baseUrl);
+        }
+
+        return $instance;
+    }
+}

--- a/tests/IntegrationTests/ItemPropertiesSetupTest.php
+++ b/tests/IntegrationTests/ItemPropertiesSetupTest.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\IntegrationTests;
+
+use Lmc\Matej\Model\Command;
+
+/**
+ * @covers \Lmc\Matej\RequestBuilder\ItemPropertiesSetupRequestBuilder
+ * @covers \Lmc\Matej\RequestBuilder\EventsRequestBuilder
+ */
+class ItemPropertiesSetupTest extends IntegrationTestCase
+{
+    /**
+     * In Matej's Mongo Worker, this will throw an error, because the property isn't defined.
+     * The API will however return OK. This is desired behaviour.
+     *
+     * @test
+     */
+    public function shouldExecuteRequestContainingUnknownPropertyButPass(): void
+    {
+        $response = $this->createMatejInstance()
+            ->request()
+            ->events()
+            ->addItemProperty(
+                Command\ItemProperty::create(
+                    'integration-test-php-clientitem-id',
+                    ['integration_test_php_client_property_1' => true, 'integration_test_php_client_property_2' => false]
+                )
+            )
+            ->send();
+
+        $this->assertSame(1, $response->getNumberOfCommands());
+        $this->assertSame(1, $response->getNumberOfSuccessfulCommands());
+        $this->assertSame(0, $response->getNumberOfFailedCommands());
+        $this->assertSame(0, $response->getNumberOfSkippedCommands());
+
+        $commandResponse = $response->getCommandResponses()[0];
+        $this->assertSame('OK', $commandResponse->getStatus());
+        $this->assertSame([], $commandResponse->getData());
+        $this->assertSame('', $commandResponse->getMessage());
+    }
+
+    /**
+     * @test
+     * @depends shouldExecuteRequestContainingUnknownPropertyButPass
+     */
+    public function shouldCreateNewPropertiesInMatej(): void
+    {
+        $response = $this->createMatejInstance()
+            ->request()
+            ->setupItemProperties()
+            ->addProperty(Command\ItemPropertySetup::boolean('integration_test_php_client_bool'))
+            ->addProperty(Command\ItemPropertySetup::double('integration_test_php_client_double'))
+            ->addProperty(Command\ItemPropertySetup::int('integration_test_php_client_int'))
+            ->addProperty(Command\ItemPropertySetup::string('integration_test_php_client_string'))
+            ->addProperties([
+                Command\ItemPropertySetup::timestamp('integration_test_php_client_timestamp'),
+                Command\ItemPropertySetup::set('integration_test_php_client_set'),
+            ])
+            ->send();
+
+        $this->assertSame(6, $response->getNumberOfCommands());
+        $this->assertSame(6, $response->getNumberOfSuccessfulCommands());
+        $this->assertSame(0, $response->getNumberOfFailedCommands());
+        $this->assertSame(0, $response->getNumberOfSkippedCommands());
+    }
+
+    /**
+     * @test
+     * @depends shouldCreateNewPropertiesInMatej
+     */
+    public function shouldExecuteEventWithJustCreatedProperties(): void
+    {
+        $response = $this->createMatejInstance()
+            ->request()
+            ->events()
+            ->addItemProperty(
+                Command\ItemProperty::create(
+                    'integration-test-php-clientitem-id',
+                    [
+                        'integration_test_php_client_bool' => true,
+                        'integration_test_php_client_double' => 0.15,
+                        'integration_test_php_client_int' => 15,
+                        'integration_test_php_client_string' => 'some_string',
+                        'integration_test_php_client_timestamp' => 123456789,
+                        'integration_test_php_client_set' => ['some', 'set'],
+                    ]
+                )
+            )
+            ->send();
+
+        $this->assertSame(1, $response->getNumberOfCommands());
+        $this->assertSame(1, $response->getNumberOfSuccessfulCommands());
+        $this->assertSame(0, $response->getNumberOfFailedCommands());
+        $this->assertSame(0, $response->getNumberOfSkippedCommands());
+    }
+
+    /**
+     * @test
+     * @depends shouldExecuteEventWithJustCreatedProperties
+     */
+    public function shouldDeleteCreatedPropertiesFromMatej(): void
+    {
+        $response = $this->createMatejInstance()
+            ->request()
+            ->deleteItemProperties()
+            ->addProperty(Command\ItemPropertySetup::boolean('integration_test_php_client_bool'))
+            ->addProperty(Command\ItemPropertySetup::double('integration_test_php_client_double'))
+            ->addProperty(Command\ItemPropertySetup::int('integration_test_php_client_int'))
+            ->addProperty(Command\ItemPropertySetup::string('integration_test_php_client_string'))
+            ->addProperties([
+                Command\ItemPropertySetup::timestamp('integration_test_php_client_timestamp'),
+                Command\ItemPropertySetup::set('integration_test_php_client_set'),
+            ])
+            ->send();
+
+        $this->assertSame(6, $response->getNumberOfCommands());
+        $this->assertSame(6, $response->getNumberOfSuccessfulCommands());
+        $this->assertSame(0, $response->getNumberOfFailedCommands());
+        $this->assertSame(0, $response->getNumberOfSkippedCommands());
+    }
+}

--- a/tests/MatejTest.php
+++ b/tests/MatejTest.php
@@ -48,4 +48,29 @@ class MatejTest extends TestCase
         $this->assertInstanceOf(CommandResponse::class, $response->getCommandResponses()[0]);
         $this->assertSame(CommandResponse::STATUS_OK, $response->getCommandResponses()[0]->getStatus());
     }
+
+    /** @test */
+    public function shouldOverwriteBaseUrl(): void
+    {
+        $dummyHttpResponse = $this->createJsonResponseFromFile(__DIR__ . '/Http/Fixtures/response-one-successful-command.json');
+
+        $mockClient = new Client();
+        $mockClient->addResponse($dummyHttpResponse);
+
+        $matej = new Matej('account-id', 'apiKey');
+        $matej->setHttpClient($mockClient);
+
+        $matej->setBaseUrl('https://nobody.nowhere.com/%s');
+
+        $matej->request()
+            ->setupItemProperties()
+            ->addProperty(ItemPropertySetup::timestamp('valid_from'))
+            ->send();
+
+        $this->assertCount(1, $mockClient->getRequests());
+        $this->assertStringStartsWith(
+            'https://nobody.nowhere.com/account-id',
+            $mockClient->getRequests()[0]->getUri()->__toString()
+        );
+    }
 }


### PR DESCRIPTION
* Uses environment variables to instantiate matej's client
* allows changing base url for local development