### PR TITLE
Sorting request

### DIFF
--- a/src/RequestBuilder/RequestBuilderFactory.php
+++ b/src/RequestBuilder/RequestBuilderFactory.php
@@ -3,6 +3,7 @@
 namespace Lmc\Matej\RequestBuilder;
 
 use Lmc\Matej\Http\RequestManager;
+use Lmc\Matej\Model\Command\Sorting;
 
 /**
  * Factory to create concrete RequestBuilder which helps you to create request for each Matej API
@@ -52,6 +53,14 @@ class RequestBuilderFactory
     public function campaign(): CampaignRequestBuilder
     {
         return $this->createConfiguredBuilder(CampaignRequestBuilder::class);
+    }
+
+    /**
+     * @return SortingRequestBuilder
+     */
+    public function sorting(Sorting $sorting): SortingRequestBuilder
+    {
+        return $this->createConfiguredBuilder(SortingRequestBuilder::class, $sorting);
     }
 
     // TODO: builders for other endpoints

--- a/src/RequestBuilder/SortingRequestBuilder.php
+++ b/src/RequestBuilder/SortingRequestBuilder.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\RequestBuilder;
+
+use Fig\Http\Message\RequestMethodInterface;
+use Lmc\Matej\Model\Command\Interaction;
+use Lmc\Matej\Model\Command\Sorting;
+use Lmc\Matej\Model\Command\UserMerge;
+use Lmc\Matej\Model\Request;
+
+class SortingRequestBuilder extends AbstractRequestBuilder
+{
+    protected const ENDPOINT_PATH = '/sorting';
+
+    /** @var Interaction|null */
+    private $interactionCommand;
+    /** @var UserMerge|null */
+    private $userMergeCommand;
+    /** @var Sorting */
+    private $sortingCommand;
+
+    public function __construct(Sorting $sortingCommand)
+    {
+        $this->sortingCommand = $sortingCommand;
+    }
+
+    public function addUserMerge(UserMerge $merge): self
+    {
+        $this->userMergeCommand = $merge;
+
+        return $this;
+    }
+
+    public function addInteraction(Interaction $interaction): self
+    {
+        $this->interactionCommand = $interaction;
+
+        return $this;
+    }
+
+    public function build(): Request
+    {
+        return new Request(
+            self::ENDPOINT_PATH,
+            RequestMethodInterface::METHOD_POST,
+            [$this->interactionCommand, $this->userMergeCommand, $this->sortingCommand]
+        );
+    }
+}

--- a/tests/IntegrationTests/IntegrationTestCase.php
+++ b/tests/IntegrationTests/IntegrationTestCase.php
@@ -3,6 +3,7 @@
 namespace Lmc\Matej\IntegrationTests;
 
 use Lmc\Matej\Matej;
+use Lmc\Matej\Model\Response;
 use Lmc\Matej\TestCase;
 
 class IntegrationTestCase extends TestCase
@@ -28,5 +29,18 @@ class IntegrationTestCase extends TestCase
         }
 
         return $instance;
+    }
+
+    protected function assertResponseCommandStatuses(Response $response, ...$expectedCommandStatuses): void
+    {
+        $this->assertSame(count($expectedCommandStatuses), $response->getNumberOfCommands());
+        $this->assertSame(count(array_intersect($expectedCommandStatuses, ['OK'])), $response->getNumberOfSuccessfulCommands());
+        $this->assertSame(count(array_intersect($expectedCommandStatuses, ['ERROR'])), $response->getNumberOfFailedCommands());
+        $this->assertSame(count(array_intersect($expectedCommandStatuses, ['SKIPPED'])), $response->getNumberOfSkippedCommands());
+
+        $commandResponses = $response->getCommandResponses();
+        foreach ($expectedCommandStatuses as $key => $expectedStatus) {
+            $this->assertSame($expectedStatus, $commandResponses[$key]->getStatus());
+        }
     }
 }

--- a/tests/IntegrationTests/SortingRequestTest.php
+++ b/tests/IntegrationTests/SortingRequestTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\IntegrationTests;
+
+use Lmc\Matej\Model\Command\Interaction;
+use Lmc\Matej\Model\Command\Sorting;
+use Lmc\Matej\Model\Command\UserMerge;
+
+/**
+ * @covers \Lmc\Matej\RequestBuilder\ItemPropertiesSetupRequestBuilder
+ * @covers \Lmc\Matej\RequestBuilder\EventsRequestBuilder
+ */
+class SortingRequestTest extends IntegrationTestCase
+{
+    /** @test */
+    public function shouldExecuteSortingRequestOnly(): void
+    {
+        $response = $this->createMatejInstance()
+            ->request()
+            ->sorting(Sorting::create('integration-test-php-client-user-id-A', ['itemA', 'itemB', 'itemC']))
+            ->send();
+
+        $this->assertResponseCommandStatuses($response, 'SKIPPED', 'SKIPPED', 'OK');
+    }
+
+    /** @test */
+    public function shouldFailOnTooLittleItemIds(): void
+    {
+        $response = $this->createMatejInstance()
+            ->request()
+            ->sorting(Sorting::create('integration-test-php-client-user-id-A', ['itemA']))
+            ->send();
+
+        $this->assertResponseCommandStatuses($response, 'SKIPPED', 'SKIPPED', 'OK');
+    }
+
+    /** @test */
+    public function shouldExecuteSortingRequestWithInteraction(): void
+    {
+        $response = $this->createMatejInstance()
+            ->request()
+            ->sorting(Sorting::create('integration-test-php-client-user-id-A', ['itemA', 'itemB', 'itemC']))
+            ->addInteraction(Interaction::bookmark('integration-test-php-client-user-id-A', 'itemA'))
+            ->send();
+
+        $this->assertResponseCommandStatuses($response, 'OK', 'SKIPPED', 'OK');
+    }
+
+    /** @test */
+    public function shouldExecuteSortingRequestWithUserMerge(): void
+    {
+        $response = $this->createMatejInstance()
+            ->request()
+            ->sorting(Sorting::create('integration-test-php-client-user-id-A', ['itemA', 'itemB', 'itemC']))
+            ->addUserMerge(UserMerge::mergeInto('integration-test-php-client-user-id-A', 'integration-test-php-client-user-id-B'))
+            ->send();
+
+        $this->assertResponseCommandStatuses($response, 'SKIPPED', 'OK', 'OK');
+    }
+
+    /** @test */
+    public function shouldExecuteSortingRequestWithUserMergeAndInteraction(): void
+    {
+        $response = $this->createMatejInstance()
+            ->request()
+            ->sorting(Sorting::create('integration-test-php-client-user-id-A', ['itemA', 'itemB', 'itemC']))
+            ->addUserMerge(UserMerge::mergeInto('integration-test-php-client-user-id-A', 'integration-test-php-client-user-id-B'))
+            ->addInteraction(Interaction::bookmark('integration-test-php-client-user-id-A', 'itemA'))
+            ->send();
+
+        $this->assertResponseCommandStatuses($response, 'OK', 'OK', 'OK');
+    }
+}

--- a/tests/Model/Command/InteractionTest.php
+++ b/tests/Model/Command/InteractionTest.php
@@ -21,6 +21,7 @@ class InteractionTest extends TestCase
     /**
      * @test
      * @dataProvider provideConstructorName
+     * @runInSeparateProcess so that time() can be mocked safely
      */
     public function shouldBeInstantiableViaNamedConstructors(
         string $constructorName,

--- a/tests/RequestBuilder/RequestBuilderFactoryTest.php
+++ b/tests/RequestBuilder/RequestBuilderFactoryTest.php
@@ -22,7 +22,8 @@ class RequestBuilderFactoryTest extends TestCase
     public function shouldInstantiateBuilderToBuildAndSendRequest(
         string $factoryMethod,
         string $expectedBuilderClass,
-        \Closure $minimalBuilderInit
+        \Closure $minimalBuilderInit,
+        ...$factoryArguments
     ): void {
         $requestManagerMock = $this->createMock(RequestManager::class);
         $requestManagerMock->expects($this->once())
@@ -33,7 +34,7 @@ class RequestBuilderFactoryTest extends TestCase
         $factory = new RequestBuilderFactory($requestManagerMock);
 
         /** @var AbstractRequestBuilder $builder */
-        $builder = $factory->$factoryMethod();
+        $builder = $factory->$factoryMethod(...$factoryArguments);
 
         // Builders may require some minimal setup to be able to execute the build() method
         $minimalBuilderInit($builder);
@@ -62,11 +63,15 @@ class RequestBuilderFactoryTest extends TestCase
             $builder->addSorting(Sorting::create('item-id', ['item1', 'item2']));
         };
 
+        $sortingInit = function (SortingRequestBuilder $builder): void {
+        };
+
         return [
             ['setupItemProperties', ItemPropertiesSetupRequestBuilder::class, $itemPropertiesSetupInit],
             ['deleteItemProperties', ItemPropertiesSetupRequestBuilder::class, $itemPropertiesSetupInit],
             ['events', EventsRequestBuilder::class, $eventInit],
             ['campaign', CampaignRequestBuilder::class, $campaignInit],
+            ['sorting', SortingRequestBuilder::class, $sortingInit, Sorting::create('user-a', ['item-a', 'item-b', 'item-c'])],
         ];
     }
 }

--- a/tests/RequestBuilder/SortingRequestBuilderTest.php
+++ b/tests/RequestBuilder/SortingRequestBuilderTest.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\RequestBuilder;
+
+use Fig\Http\Message\RequestMethodInterface;
+use Lmc\Matej\Exception\LogicException;
+use Lmc\Matej\Http\RequestManager;
+use Lmc\Matej\Model\Command\Interaction;
+use Lmc\Matej\Model\Command\Sorting;
+use Lmc\Matej\Model\Command\UserMerge;
+use Lmc\Matej\Model\Request;
+use Lmc\Matej\Model\Response;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lmc\Matej\RequestBuilder\SortingRequestBuilder
+ * @covers \Lmc\Matej\RequestBuilder\AbstractRequestBuilder
+ */
+class SortingRequestBuilderTest extends TestCase
+{
+    /** @test */
+    public function shouldBuildRequestWithCommands(): void
+    {
+        $sortingCommand = Sorting::create('userId1', ['itemId1', 'itemId2']);
+        $builder = new SortingRequestBuilder($sortingCommand);
+
+        $interactionCommand = Interaction::detailView('userId1', 'itemId1');
+        $builder->addInteraction($interactionCommand);
+
+        $userMergeCommand = UserMerge::mergeFromSourceToTargetUser('sourceId1', 'targetId1');
+        $builder->addUserMerge($userMergeCommand);
+
+        $request = $builder->build();
+
+        $this->assertInstanceOf(Request::class, $request);
+        $this->assertSame(RequestMethodInterface::METHOD_POST, $request->getMethod());
+        $this->assertSame('/sorting', $request->getPath());
+
+        $requestData = $request->getData();
+        $this->assertCount(3, $requestData);
+        $this->assertSame($interactionCommand, $requestData[0]);
+        $this->assertSame($userMergeCommand, $requestData[1]);
+        $this->assertSame($sortingCommand, $requestData[2]);
+    }
+
+    /** @test */
+    public function shouldThrowExceptionWhenSendingCommandsWithoutRequestManager(): void
+    {
+        $builder = new SortingRequestBuilder(Sorting::create('userId1', ['itemId1', 'itemId2']));
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Instance of RequestManager must be set to request builder');
+        $builder->send();
+    }
+
+    /** @test */
+    public function shouldSendRequestViaRequestManager(): void
+    {
+        $requestManagerMock = $this->createMock(RequestManager::class);
+        $requestManagerMock->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->isInstanceOf(Request::class))
+            ->willReturn(new Response(0, 0, 0, 0));
+
+        $builder = new SortingRequestBuilder(Sorting::create('userId1', ['itemId1', 'itemId2']));
+        $builder->setRequestManager($requestManagerMock);
+        $builder->send();
+    }
+}


### PR DESCRIPTION
~~PR currently references `feature/integration-test-case` until #40 is merged (to show nicer DIFF)~~

Closes #36 

Sorting command request. API usage:

```php
$response = $this->createMatejInstance()
            ->request()
            ->sorting(Sorting::create('integration-test-php-client-user-id-A', ['itemA', 'itemB', 'itemC']))
            ->addUserMerge(UserMerge::mergeInto('user-id-A', 'user-id-B')) // optional
            ->addInteraction(Interaction::bookmark('user-id-A', 'itemA')) // optional
            ->send();
```