### PR TITLE
Validate command data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 - All exceptions now implement `MatejExceptionInterface` instead of subclassing `AbstractMatejException`.
 - Exceptions raised during response processing are now all of `ResponseDecodingException` type.
+- Values passed to Command objects are now validated on construction and throws `Lmc\Matej\Exception\DomainException` when invalid.
 
 ## 0.9.0 - 2017-11-27
 ### Added

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ The exception tree is:
 | &nbsp;&nbsp;└ AuthorizationException              | Request errored as unauthorized                               |
 | └ ResponseDecodingException                       | Response contains invalid or inconsistent data                |
 | └ LogicException                                  | Incorrect library use - no data passed to request etc.        |
+| &nbsp;&nbsp;└ DomainException                     | Invalid value was passed to domain model                      |
 
 Please note if you inject custom HTTP client (via `$matej->setHttpClient()`), it may be configured to throw custom
 exceptions when HTTP request fails. So please make sure this behavior is disabled (eg. `http_errors` option in Guzzle 6).

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "php-http/client-implementation": "^1.0",
         "php-http/discovery": "^1.0",
         "fig/http-message-util": "^1.1",
-        "php-http/client-common": "^1.6"
+        "php-http/client-common": "^1.6",
+        "beberlei/assert": "^2.7"
     },
     "require-dev": {
         "php-http/guzzle6-adapter": "^1.1",

--- a/src/Exception/DomainException.php
+++ b/src/Exception/DomainException.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Exception;
+
+use Assert\AssertionFailedException;
+
+/**
+ * Exception thrown when invalid value is passed while creating domain model.
+ *
+ * @codeCoverageIgnore
+ */
+class DomainException extends LogicException implements AssertionFailedException
+{
+    /** @var string|null */
+    private $propertyPath;
+    /** @var mixed */
+    private $value;
+    /** @var array */
+    private $constraints;
+
+    public function __construct(string $message, int $code, ?string $propertyPath, $value, array $constraints = [])
+    {
+        parent::__construct($message, $code);
+
+        $this->propertyPath = $propertyPath;
+        $this->value = $value;
+        $this->constraints = $constraints;
+    }
+
+    public function getPropertyPath(): ?string
+    {
+        return $this->propertyPath;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function getConstraints(): array
+    {
+        return $this->constraints;
+    }
+}

--- a/src/Model/Assertion.php
+++ b/src/Model/Assertion.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model;
+
+use Lmc\Matej\Exception\DomainException;
+
+/**
+ * @method static bool allTypeIdentifier(mixed $value) Assert value is valid Matej type identifier for all values
+ */
+class Assertion extends \Assert\Assertion
+{
+    protected static $exceptionClass = DomainException::class;
+
+    /**
+     * Assert value is valid Matej type identifier
+     * @param mixed $value
+     */
+    public static function typeIdentifier($value): bool
+    {
+        static::regex(
+            $value,
+            '/^[0-9A-Za-z-_]+$/',
+            'Value "%s" does not match type identifier format requirement (must contain only of alphanumeric chars,'
+            . ' dash or underscore)'
+        );
+        static::maxLength($value, 100);
+
+        return true;
+    }
+}

--- a/src/Model/Command/Interaction.php
+++ b/src/Model/Command/Interaction.php
@@ -2,6 +2,8 @@
 
 namespace Lmc\Matej\Model\Command;
 
+use Lmc\Matej\Model\Assertion;
+
 /**
  * Interaction command allows to send one interaction between a user and item.
  * When given user or item identifier is unknown, Matej will create such user or item respectively.
@@ -34,12 +36,12 @@ class Interaction extends AbstractCommand
         string $context = 'default',
         int $timestamp = null
     ) {
-        $this->interactionType = $interactionType; // TODO: assert one of INTERACTION_TYPE_*
-        $this->userId = $userId; // TODO: assert format
-        $this->itemId = $itemId; // TODO: assert format
-        $this->value = $value; // TODO: assert value between 0-1
-        $this->context = $context; // TODO: assert format
-        $this->timestamp = $timestamp ?: time(); // TODO: assert format
+        $this->interactionType = $interactionType;
+        $this->setUserId($userId);
+        $this->setItemId($itemId);
+        $this->setValue($value);
+        $this->setContext($context);
+        $this->setTimestamp($timestamp ?? time());
     }
 
     /**
@@ -120,5 +122,40 @@ class Interaction extends AbstractCommand
             'value' => $this->value,
             'context' => $this->context,
         ];
+    }
+
+    protected function setUserId(string $userId): void
+    {
+        Assertion::typeIdentifier($userId);
+
+        $this->userId = $userId;
+    }
+
+    protected function setItemId(string $itemId): void
+    {
+        Assertion::typeIdentifier($itemId);
+
+        $this->itemId = $itemId;
+    }
+
+    protected function setValue(float $value): void
+    {
+        Assertion::between($value, 0, 1);
+
+        $this->value = $value;
+    }
+
+    protected function setContext(string $context): void
+    {
+        Assertion::typeIdentifier($context);
+
+        $this->context = $context;
+    }
+
+    protected function setTimestamp(int $timestamp): void
+    {
+        Assertion::greaterThan($timestamp, 0);
+
+        $this->timestamp = $timestamp;
     }
 }

--- a/src/Model/Command/ItemProperty.php
+++ b/src/Model/Command/ItemProperty.php
@@ -2,6 +2,8 @@
 
 namespace Lmc\Matej\Model\Command;
 
+use Lmc\Matej\Model\Assertion;
+
 /**
  * Command to save different item content properties to Matej.
  */
@@ -14,15 +16,20 @@ class ItemProperty extends AbstractCommand
 
     private function __construct(string $itemId, array $properties)
     {
-        // TODO: assert itemId format
-
-        $this->itemId = $itemId;
+        $this->setItemId($itemId);
         $this->properties = $properties;
     }
 
     public static function create(string $itemId, array $properties = []): self
     {
         return new static($itemId, $properties);
+    }
+
+    protected function setItemId(string $itemId): void
+    {
+        Assertion::typeIdentifier($itemId);
+
+        $this->itemId = $itemId;
     }
 
     protected function getCommandType(): string

--- a/src/Model/Command/ItemPropertySetup.php
+++ b/src/Model/Command/ItemPropertySetup.php
@@ -2,6 +2,8 @@
 
 namespace Lmc\Matej\Model\Command;
 
+use Lmc\Matej\Model\Assertion;
+
 /**
  * Command to add or delete item property in the database.
  */
@@ -21,10 +23,7 @@ class ItemPropertySetup extends AbstractCommand
 
     private function __construct(string $propertyName, string $propertyType)
     {
-        // TODO: assert propertyName format
-        // TODO: assert propertyType is one of PROPERTY_TYPE_*
-
-        $this->propertyName = $propertyName;
+        $this->setPropertyName($propertyName);
         $this->propertyType = $propertyType;
     }
 
@@ -56,6 +55,13 @@ class ItemPropertySetup extends AbstractCommand
     public static function set(string $propertyName): self
     {
         return new static($propertyName, self::PROPERTY_TYPE_SET);
+    }
+
+    protected function setPropertyName(string $propertyName): void
+    {
+        Assertion::typeIdentifier($propertyName);
+
+        $this->propertyName = $propertyName;
     }
 
     protected function getCommandType(): string

--- a/src/Model/Command/Sorting.php
+++ b/src/Model/Command/Sorting.php
@@ -2,6 +2,8 @@
 
 namespace Lmc\Matej\Model\Command;
 
+use Lmc\Matej\Model\Assertion;
+
 /**
  * Sorting items is a way how to use Matej to deliver personalized experience to users.
  * It allows to sort given list of items according to the user preference.
@@ -15,8 +17,8 @@ class Sorting extends AbstractCommand
 
     private function __construct(string $userId, array $itemIds)
     {
-        $this->userId = $userId;
-        $this->itemIds = $itemIds;
+        $this->setUserId($userId);
+        $this->setItemIds($itemIds);
     }
 
     /**
@@ -27,12 +29,26 @@ class Sorting extends AbstractCommand
         return new static($userId, $itemIds);
     }
 
-    public function getCommandType(): string
+    protected function setUserId(string $userId): void
+    {
+        Assertion::typeIdentifier($userId);
+
+        $this->userId = $userId;
+    }
+
+    protected function setItemIds(array $itemIds): void
+    {
+        Assertion::allTypeIdentifier($itemIds);
+
+        $this->itemIds = $itemIds;
+    }
+
+    protected function getCommandType(): string
     {
         return 'sorting';
     }
 
-    public function getCommandParameters(): array
+    protected function getCommandParameters(): array
     {
         return [
             'user_id' => $this->userId,

--- a/src/Model/Command/UserMerge.php
+++ b/src/Model/Command/UserMerge.php
@@ -2,6 +2,8 @@
 
 namespace Lmc\Matej\Model\Command;
 
+use Lmc\Matej\Model\Assertion;
+
 /**
  * Take all interactions from the source user and merge them to the target user.
  * Source user will be DELETED and unknown to Matej from this action.
@@ -15,8 +17,8 @@ class UserMerge extends AbstractCommand
 
     private function __construct(string $targetUserId, string $sourceUserId)
     {
-        $this->targetUserId = $targetUserId;
-        $this->sourceUserId = $sourceUserId;
+        $this->setTargetUserId($targetUserId);
+        $this->setSourceUserId($sourceUserId);
     }
 
     /**
@@ -35,12 +37,26 @@ class UserMerge extends AbstractCommand
         return new static($targetUserId, $sourceUserIdToBeDeleted);
     }
 
-    public function getCommandType(): string
+    protected function setSourceUserId(string $sourceUserId): void
+    {
+        Assertion::typeIdentifier($sourceUserId);
+
+        $this->sourceUserId = $sourceUserId;
+    }
+
+    protected function setTargetUserId(string $targetUserId): void
+    {
+        Assertion::typeIdentifier($targetUserId);
+
+        $this->targetUserId = $targetUserId;
+    }
+
+    protected function getCommandType(): string
     {
         return 'user-merge';
     }
 
-    public function getCommandParameters(): array
+    protected function getCommandParameters(): array
     {
         return [
             'target_user_id' => $this->targetUserId,

--- a/src/Model/Command/UserRecommendation.php
+++ b/src/Model/Command/UserRecommendation.php
@@ -2,6 +2,8 @@
 
 namespace Lmc\Matej\Model\Command;
 
+use Lmc\Matej\Model\Assertion;
+
 /**
  * Deliver personalized recommendations for the given user.
  */
@@ -32,11 +34,11 @@ class UserRecommendation extends AbstractCommand
 
     private function __construct(string $userId, int $count, string $scenario, float $rotationRate, int $rotationTime)
     {
-        $this->userId = $userId; // TODO: assert format
-        $this->count = $count; // TODO: assert greater than 0
-        $this->scenario = $scenario; // TODO: assert format
-        $this->rotationRate = $rotationRate; // TODO: assert value between 0.0 and 1.0
-        $this->rotationTime = $rotationTime; // TODO: assert valid time interval
+        $this->setUserId($userId);
+        $this->setCount($count);
+        $this->setScenario($scenario);
+        $this->setRotationRate($rotationRate);
+        $this->setRotationTime($rotationTime);
     }
 
     /**
@@ -79,7 +81,11 @@ class UserRecommendation extends AbstractCommand
      */
     public function setMinimalRelevance(string $minimalRelevance): self
     {
-        // TODO: assert one of MIN_RELEVANCE_*
+        Assertion::choice(
+            $minimalRelevance,
+            [self::MINIMAL_RELEVANCE_LOW, self::MINIMAL_RELEVANCE_MEDIUM, self::MINIMAL_RELEVANCE_HIGH]
+        );
+
         $this->minimalRelevance = $minimalRelevance;
 
         return $this;
@@ -100,9 +106,51 @@ class UserRecommendation extends AbstractCommand
      */
     public function setFilters(array $filters): self
     {
+        Assertion::allString($filters);
+
         $this->filters = $filters;
 
         return $this;
+    }
+
+    protected function setUserId(string $userId): void
+    {
+        Assertion::typeIdentifier($userId);
+
+        $this->userId = $userId;
+    }
+
+    protected function setCount(int $count): void
+    {
+        Assertion::greaterThan($count, 0);
+
+        $this->count = $count;
+    }
+
+    protected function setScenario(string $scenario): void
+    {
+        Assertion::typeIdentifier($scenario);
+
+        $this->scenario = $scenario;
+    }
+
+    protected function setRotationRate(float $rotationRate): void
+    {
+        Assertion::between($rotationRate, 0, 1);
+
+        $this->rotationRate = $rotationRate;
+    }
+
+    protected function setRotationTime(int $rotationTime): void
+    {
+        Assertion::greaterThan($rotationTime, 0);
+
+        $this->rotationTime = $rotationTime;
+    }
+
+    protected function assembleFiltersString(): string
+    {
+        return implode(' ' . $this->filterOperator . ' ', $this->filters);
     }
 
     protected function getCommandType(): string
@@ -122,10 +170,5 @@ class UserRecommendation extends AbstractCommand
             'min_relevance' => $this->minimalRelevance,
             'filter' => $this->assembleFiltersString(),
         ];
-    }
-
-    protected function assembleFiltersString(): string
-    {
-        return implode(' ' . $this->filterOperator . ' ', $this->filters);
     }
 }

--- a/tests/Model/AssertionTest.php
+++ b/tests/Model/AssertionTest.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model;
+
+use Lmc\Matej\Exception\DomainException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lmc\Matej\Model\Assertion
+ */
+class AssertionTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider provideValidTypeIdentifiers
+     */
+    public function shouldAssertValidTypeIdentifier(string $typeIdentifier): void
+    {
+        $this->assertTrue(Assertion::typeIdentifier($typeIdentifier));
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideValidTypeIdentifiers(): array
+    {
+        return [
+            'single character' => ['a'],
+            'lower/upper case combination' => ['FOObar'],
+            'numbers, dashes' => ['foo-123'],
+            'cases, numbers, uderscore, dash' => ['fOoO_13-37'],
+            'starts with number' => ['123-foo'],
+            'number as string' => ['666333666333'],
+            'max length (100 characters)' => [str_repeat('a', 100)],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider provideInvalidTypeIdentifiers
+     * @param mixed $typeIdentifier
+     * @param string $expectedExceptionMessage
+     */
+    public function shouldAssertInvalidTypeIdentifier($typeIdentifier, string $expectedExceptionMessage): void
+    {
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+        Assertion::typeIdentifier($typeIdentifier);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideInvalidTypeIdentifiers(): array
+    {
+        $formatExceptionMessage = 'does not match type identifier format requirement';
+        $lengthExceptionMessage = 'is too long, it should have no more than 100 characters';
+
+        return [
+            'empty' => ['', $formatExceptionMessage],
+            'special national characters' => ['föbär', $formatExceptionMessage],
+            'at character' => ['user@email', $formatExceptionMessage],
+            'integer' => [333666, $formatExceptionMessage],
+            'over max length (>100 characters)' => [str_repeat('a', 101), $lengthExceptionMessage],
+        ];
+    }
+}


### PR DESCRIPTION
As mentioned in #28 , the plan is to allow setting only those values, allowed by Matej's API (and Matej JSON schema), so that you will get the feedback that your data are wrong sooner, even without sending them to Matej API (which will reject them).

I'd like to add the assertions in a similar way (via protected constructors - to not put all the assertions into constructor) to all Commands etc. Any comments, ideas?