### PR TITLE
 Assert commands of recommendation and sorting involve the same user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+### Added
+- Commands which include user now implements `UserAwareInterface` and `getUserId()` method (ie. Interaction, Sorting, UserMerge, UserRecommendation).
 
 ## 0.10.0 - 2017-11-30
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Added
 - Commands which include user now implements `UserAwareInterface` and `getUserId()` method (ie. Interaction, Sorting, UserMerge, UserRecommendation).
 
+### Changed
+- Validate all commands of `recommendation()` and `sorting()` request involve the same user.
+
 ## 0.10.0 - 2017-11-30
 ### Changed
 - All exceptions now implement `MatejExceptionInterface` instead of subclassing `AbstractMatejException`.

--- a/src/Exception/LogicException.php
+++ b/src/Exception/LogicException.php
@@ -2,9 +2,23 @@
 
 namespace Lmc\Matej\Exception;
 
+use Lmc\Matej\Model\Command\UserAwareInterface;
+
 /**
  * Exception represents error in the program logic.
  */
 class LogicException extends \LogicException implements MatejExceptionInterface
 {
+    public static function forInconsistentUserId(UserAwareInterface $mainCommand, UserAwareInterface $additionalCommand)
+    {
+        $message = sprintf(
+            'User in %s command ("%s") must be the same as user in %s command ("%s")',
+            (new \ReflectionClass($additionalCommand))->getShortName(),
+            $additionalCommand->getUserId(),
+            (new \ReflectionClass($mainCommand))->getShortName(),
+            $mainCommand->getUserId()
+        );
+
+        return new self($message);
+    }
 }

--- a/src/Model/Command/Interaction.php
+++ b/src/Model/Command/Interaction.php
@@ -8,7 +8,7 @@ use Lmc\Matej\Model\Assertion;
  * Interaction command allows to send one interaction between a user and item.
  * When given user or item identifier is unknown, Matej will create such user or item respectively.
  */
-class Interaction extends AbstractCommand
+class Interaction extends AbstractCommand implements UserAwareInterface
 {
     private const INTERACTION_TYPE_DETAILVIEWS = 'detailviews';
     private const INTERACTION_TYPE_PURCHASES = 'purchases';
@@ -105,6 +105,11 @@ class Interaction extends AbstractCommand
         int $timestamp = null
     ): self {
         return new static(self::INTERACTION_TYPE_RATINGS, $userId, $itemId, $value, $context, $timestamp);
+    }
+
+    public function getUserId(): string
+    {
+        return $this->userId;
     }
 
     public function getCommandType(): string

--- a/src/Model/Command/Sorting.php
+++ b/src/Model/Command/Sorting.php
@@ -8,7 +8,7 @@ use Lmc\Matej\Model\Assertion;
  * Sorting items is a way how to use Matej to deliver personalized experience to users.
  * It allows to sort given list of items according to the user preference.
  */
-class Sorting extends AbstractCommand
+class Sorting extends AbstractCommand implements UserAwareInterface
 {
     /** @var string */
     private $userId;
@@ -27,6 +27,11 @@ class Sorting extends AbstractCommand
     public static function create(string $userId, array $itemIds): self
     {
         return new static($userId, $itemIds);
+    }
+
+    public function getUserId(): string
+    {
+        return $this->userId;
     }
 
     protected function setUserId(string $userId): void

--- a/src/Model/Command/UserAwareInterface.php
+++ b/src/Model/Command/UserAwareInterface.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model\Command;
+
+/**
+ * Commands implementing this interface are aware of user, which is affected by the commands.
+ */
+interface UserAwareInterface
+{
+    public function getUserId(): string;
+}

--- a/src/Model/Command/UserMerge.php
+++ b/src/Model/Command/UserMerge.php
@@ -8,7 +8,7 @@ use Lmc\Matej\Model\Assertion;
  * Take all interactions from the source user and merge them to the target user.
  * Source user will be DELETED and unknown to Matej from this action.
  */
-class UserMerge extends AbstractCommand
+class UserMerge extends AbstractCommand implements UserAwareInterface
 {
     /** @var string */
     private $sourceUserId;
@@ -35,6 +35,11 @@ class UserMerge extends AbstractCommand
     public static function mergeFromSourceToTargetUser(string $sourceUserIdToBeDeleted, string $targetUserId): self
     {
         return new static($targetUserId, $sourceUserIdToBeDeleted);
+    }
+
+    public function getUserId(): string
+    {
+        return $this->targetUserId;
     }
 
     protected function setSourceUserId(string $sourceUserId): void

--- a/src/Model/Command/UserRecommendation.php
+++ b/src/Model/Command/UserRecommendation.php
@@ -7,7 +7,7 @@ use Lmc\Matej\Model\Assertion;
 /**
  * Deliver personalized recommendations for the given user.
  */
-class UserRecommendation extends AbstractCommand
+class UserRecommendation extends AbstractCommand implements UserAwareInterface
 {
     public const MINIMAL_RELEVANCE_LOW = 'low';
     public const MINIMAL_RELEVANCE_MEDIUM = 'medium';
@@ -111,6 +111,11 @@ class UserRecommendation extends AbstractCommand
         $this->filters = $filters;
 
         return $this;
+    }
+
+    public function getUserId(): string
+    {
+        return $this->userId;
     }
 
     protected function setUserId(string $userId): void

--- a/src/RequestBuilder/SortingRequestBuilder.php
+++ b/src/RequestBuilder/SortingRequestBuilder.php
@@ -3,6 +3,7 @@
 namespace Lmc\Matej\RequestBuilder;
 
 use Fig\Http\Message\RequestMethodInterface;
+use Lmc\Matej\Exception\LogicException;
 use Lmc\Matej\Model\Command\Interaction;
 use Lmc\Matej\Model\Command\Sorting;
 use Lmc\Matej\Model\Command\UserMerge;
@@ -40,10 +41,24 @@ class SortingRequestBuilder extends AbstractRequestBuilder
 
     public function build(): Request
     {
+        $this->assertConsistentUsersInCommands();
+
         return new Request(
             self::ENDPOINT_PATH,
             RequestMethodInterface::METHOD_POST,
             [$this->interactionCommand, $this->userMergeCommand, $this->sortingCommand]
         );
+    }
+
+    private function assertConsistentUsersInCommands(): void
+    {
+        $mainCommandUser = $this->sortingCommand->getUserId();
+        if ($this->interactionCommand !== null && $mainCommandUser !== $this->interactionCommand->getUserId()) {
+            throw LogicException::forInconsistentUserId($this->sortingCommand, $this->interactionCommand);
+        }
+
+        if ($this->userMergeCommand !== null && $mainCommandUser !== $this->userMergeCommand->getUserId()) {
+            throw LogicException::forInconsistentUserId($this->sortingCommand, $this->userMergeCommand);
+        }
     }
 }

--- a/tests/Model/Command/InteractionTest.php
+++ b/tests/Model/Command/InteractionTest.php
@@ -51,6 +51,7 @@ class InteractionTest extends TestCase
             ],
             $command->jsonSerialize()
         );
+        $this->assertSame('exampleUserId', $command->getUserId());
     }
 
     /**

--- a/tests/Model/Command/SortingTest.php
+++ b/tests/Model/Command/SortingTest.php
@@ -13,16 +13,16 @@ class SortingTest extends TestCase
         $itemIds = ['item-1', 'item-3', 'item-2'];
 
         $command = Sorting::create($userId, $itemIds);
-        $this->assertSortingObject($command, $userId, $itemIds);
+        $this->assertSortingCommand($command, $userId, $itemIds);
     }
 
     /**
-     * Execute asserts against user merge object
-     * @param Sorting $object
+     * Execute asserts against user merge command
+     * @param Sorting $command
      */
-    private function assertSortingObject($object, string $userId, array $itemIds): void
+    private function assertSortingCommand($command, string $userId, array $itemIds): void
     {
-        $this->assertInstanceOf(Sorting::class, $object);
+        $this->assertInstanceOf(Sorting::class, $command);
         $this->assertSame(
             [
                 'type' => 'sorting',
@@ -31,7 +31,8 @@ class SortingTest extends TestCase
                     'item_ids' => $itemIds,
                 ],
             ],
-            $object->jsonSerialize()
+            $command->jsonSerialize()
         );
+        $this->assertSame($userId, $command->getUserId());
     }
 }

--- a/tests/Model/Command/UserMergeTest.php
+++ b/tests/Model/Command/UserMergeTest.php
@@ -13,19 +13,19 @@ class UserMergeTest extends TestCase
         $targetUserId = 'target-user';
 
         $command = UserMerge::mergeInto($targetUserId, $sourceUserId);
-        $this->assertUserMergeObject($command, $sourceUserId, $targetUserId);
+        $this->assertUserMergeCommand($command, $sourceUserId, $targetUserId);
 
         $command = UserMerge::mergeFromSourceToTargetUser($sourceUserId, $targetUserId);
-        $this->assertUserMergeObject($command, $sourceUserId, $targetUserId);
+        $this->assertUserMergeCommand($command, $sourceUserId, $targetUserId);
     }
 
     /**
-     * Execute asserts against user merge object
-     * @param UserMerge $object
+     * Execute asserts against user merge command
+     * @param UserMerge $command
      */
-    private function assertUserMergeObject($object, string $sourceUserId, string $targetUserId): void
+    private function assertUserMergeCommand($command, string $sourceUserId, string $targetUserId): void
     {
-        $this->assertInstanceOf(UserMerge::class, $object);
+        $this->assertInstanceOf(UserMerge::class, $command);
         $this->assertSame(
             [
                 'type' => 'user-merge',
@@ -34,7 +34,8 @@ class UserMergeTest extends TestCase
                     'source_user_id' => $sourceUserId,
                 ],
             ],
-            $object->jsonSerialize()
+            $command->jsonSerialize()
         );
+        $this->assertSame($targetUserId, $command->getUserId());
     }
 }

--- a/tests/Model/Command/UserRecommendationTest.php
+++ b/tests/Model/Command/UserRecommendationTest.php
@@ -28,6 +28,7 @@ class UserRecommendationTest extends TestCase
             ],
             $command->jsonSerialize()
         );
+        $this->assertSame('user-id', $command->getUserId());
     }
 
     /** @test */


### PR DESCRIPTION
Matej will reject recommendation/sorting request which mixes different users. IMHO we should give the feedback to the API user that he uses it wrong ASAP, and not wait on the rejected API response.

Does it makes sense in this way? Or do you have any suggestions?

Ref. #14 