### PR TITLE
Allow to set custom request id and decode response id from the response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 - Validate all commands of `recommendation()` and `sorting()` request involve the same user.
+- Custom request ID could be passed to a request (via `setRequestId()` method of request builders). If none is set, random request ID is generated.
 
 ## 0.10.0 - 2017-11-30
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changed
 - Validate all commands of `recommendation()` and `sorting()` request involve the same user.
 - Custom request ID could be passed to a request (via `setRequestId()` method of request builders). If none is set, random request ID is generated.
+- Response ID could be read from the response via `getRequestId()` method of the Response object.
 
 ## 0.10.0 - 2017-11-30
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "php-http/discovery": "^1.0",
         "fig/http-message-util": "^1.1",
         "php-http/client-common": "^1.6",
-        "beberlei/assert": "^2.7"
+        "beberlei/assert": "^2.7",
+        "ramsey/uuid": "^3.7"
     },
     "require-dev": {
         "php-http/guzzle6-adapter": "^1.1",

--- a/src/Http/RequestManager.php
+++ b/src/Http/RequestManager.php
@@ -23,6 +23,7 @@ class RequestManager
 {
     public const CLIENT_VERSION_HEADER = 'Matej-Client-Version';
     public const REQUEST_ID_HEADER = 'Matej-Request-Id';
+    public const RESPONSE_ID_HEADER = 'Matej-Response-Id';
 
     /** @var string */
     private $baseUrl = 'https://%s.matej.lmc.cz';

--- a/src/Http/RequestManager.php
+++ b/src/Http/RequestManager.php
@@ -22,6 +22,7 @@ use Psr\Http\Message\RequestInterface;
 class RequestManager
 {
     public const CLIENT_VERSION_HEADER = 'Matej-Client-Version';
+    public const REQUEST_ID_HEADER = 'Matej-Request-Id';
 
     /** @var string */
     private $baseUrl = 'https://%s.matej.lmc.cz';
@@ -127,7 +128,10 @@ class RequestManager
             ->createRequest(
                 $request->getMethod(),
                 $uri,
-                ['Content-Type' => 'application/json'],
+                [
+                    'Content-Type' => 'application/json',
+                    self::REQUEST_ID_HEADER => $request->getRequestId(),
+                ],
                 $requestBody
             );
     }

--- a/src/Http/ResponseDecoder.php
+++ b/src/Http/ResponseDecoder.php
@@ -20,12 +20,15 @@ class ResponseDecoder implements ResponseDecoderInterface
             throw ResponseDecodingException::forInvalidData($httpResponse);
         }
 
+        $responseId = $httpResponse->getHeader(RequestManager::RESPONSE_ID_HEADER)[0] ?? null;
+
         return new Response(
             (int) $responseData->commands->number_of_commands,
             (int) $responseData->commands->number_of_successful_commands,
             (int) $responseData->commands->number_of_failed_commands,
             (int) $responseData->commands->number_of_skipped_commands,
-            $responseData->commands->responses
+            $responseData->commands->responses,
+            $responseId
         );
     }
 

--- a/src/Model/Request.php
+++ b/src/Model/Request.php
@@ -2,6 +2,8 @@
 
 namespace Lmc\Matej\Model;
 
+use Ramsey\Uuid\Uuid;
+
 /**
  * Represents request to Matej prepared to be executed by `RequestManager`.
  */
@@ -13,12 +15,15 @@ class Request
     private $method;
     /** @var array */
     private $data;
+    /** @var string */
+    private $requestId;
 
-    public function __construct(string $path, string $method, array $data)
+    public function __construct(string $path, string $method, array $data, string $requestId = null)
     {
         $this->path = $path;
         $this->method = $method;
         $this->data = $data;
+        $this->requestId = $requestId ?? Uuid::uuid4()->toString();
     }
 
     public function getPath(): string
@@ -34,5 +39,10 @@ class Request
     public function getData(): array
     {
         return $this->data;
+    }
+
+    public function getRequestId(): string
+    {
+        return $this->requestId;
     }
 }

--- a/src/Model/Response.php
+++ b/src/Model/Response.php
@@ -16,18 +16,22 @@ class Response
     private $numberOfFailedCommands;
     /** @var int */
     private $numberOfSkippedCommands;
+    /** @var string|null */
+    private $responseId;
 
     public function __construct(
         int $numberOfCommands,
         int $numberOfSuccessfulCommands,
         int $numberOfFailedCommands,
         int $numberOfSkippedCommands,
-        array $commandResponses = []
+        array $commandResponses = [],
+        string $responseId = null
     ) {
         $this->numberOfCommands = $numberOfCommands;
         $this->numberOfSuccessfulCommands = $numberOfSuccessfulCommands;
         $this->numberOfFailedCommands = $numberOfFailedCommands;
         $this->numberOfSkippedCommands = $numberOfSkippedCommands;
+        $this->responseId = $responseId;
 
         foreach ($commandResponses as $rawCommandResponse) {
             $this->commandResponses[] = CommandResponse::createFromRawCommandResponseObject($rawCommandResponse);
@@ -51,6 +55,7 @@ class Response
                 $this->numberOfSkippedCommands
             );
         }
+        $this->responseId = $responseId;
     }
 
     public function getNumberOfCommands(): int
@@ -82,5 +87,10 @@ class Response
     public function getCommandResponses(): array
     {
         return $this->commandResponses;
+    }
+
+    public function getResponseId(): ?string
+    {
+        return $this->responseId;
     }
 }

--- a/src/RequestBuilder/AbstractRequestBuilder.php
+++ b/src/RequestBuilder/AbstractRequestBuilder.php
@@ -17,6 +17,8 @@ abstract class AbstractRequestBuilder
 {
     /** @var RequestManager */
     protected $requestManager;
+    /** @var string */
+    protected $requestId;
 
     /**
      * Use Commands and other settings which were passed to this builder object to build instance of
@@ -31,6 +33,19 @@ abstract class AbstractRequestBuilder
     public function setRequestManager(RequestManager $requestManager): self
     {
         $this->requestManager = $requestManager;
+
+        return $this;
+    }
+
+    /**
+     * Set custom identifier of the request to make it traceable in case of debugging.
+     * The same ID will then also be available in the response.
+     *
+     * @see Response::getResponseId()
+     */
+    public function setRequestId(string $requestId): self
+    {
+        $this->requestId = $requestId;
 
         return $this;
     }

--- a/src/RequestBuilder/CampaignRequestBuilder.php
+++ b/src/RequestBuilder/CampaignRequestBuilder.php
@@ -62,6 +62,6 @@ class CampaignRequestBuilder extends AbstractRequestBuilder
             throw new LogicException('At least one command must be added to the builder before sending the request');
         }
 
-        return new Request(self::ENDPOINT_PATH, RequestMethodInterface::METHOD_POST, $this->commands);
+        return new Request(self::ENDPOINT_PATH, RequestMethodInterface::METHOD_POST, $this->commands, $this->requestId);
     }
 }

--- a/src/RequestBuilder/EventsRequestBuilder.php
+++ b/src/RequestBuilder/EventsRequestBuilder.php
@@ -83,6 +83,6 @@ class EventsRequestBuilder extends AbstractRequestBuilder
             throw new LogicException('At least one command must be added to the builder before sending the request');
         }
 
-        return new Request(self::ENDPOINT_PATH, RequestMethodInterface::METHOD_POST, $this->commands);
+        return new Request(self::ENDPOINT_PATH, RequestMethodInterface::METHOD_POST, $this->commands, $this->requestId);
     }
 }

--- a/src/RequestBuilder/ItemPropertiesSetupRequestBuilder.php
+++ b/src/RequestBuilder/ItemPropertiesSetupRequestBuilder.php
@@ -54,6 +54,6 @@ class ItemPropertiesSetupRequestBuilder extends AbstractRequestBuilder
 
         $method = $this->shouldDelete ? RequestMethodInterface::METHOD_DELETE : RequestMethodInterface::METHOD_PUT;
 
-        return new Request(self::ENDPOINT_PATH, $method, $this->commands);
+        return new Request(self::ENDPOINT_PATH, $method, $this->commands, $this->requestId);
     }
 }

--- a/src/RequestBuilder/RecommendationRequestBuilder.php
+++ b/src/RequestBuilder/RecommendationRequestBuilder.php
@@ -46,7 +46,8 @@ class RecommendationRequestBuilder extends AbstractRequestBuilder
         return new Request(
             self::ENDPOINT_PATH,
             RequestMethodInterface::METHOD_POST,
-            [$this->interactionCommand, $this->userMergeCommand, $this->userRecommendationCommand]
+            [$this->interactionCommand, $this->userMergeCommand, $this->userRecommendationCommand],
+            $this->requestId
         );
     }
 

--- a/src/RequestBuilder/SortingRequestBuilder.php
+++ b/src/RequestBuilder/SortingRequestBuilder.php
@@ -46,7 +46,8 @@ class SortingRequestBuilder extends AbstractRequestBuilder
         return new Request(
             self::ENDPOINT_PATH,
             RequestMethodInterface::METHOD_POST,
-            [$this->interactionCommand, $this->userMergeCommand, $this->sortingCommand]
+            [$this->interactionCommand, $this->userMergeCommand, $this->sortingCommand],
+            $this->requestId
         );
     }
 

--- a/tests/Http/RequestManagerTest.php
+++ b/tests/Http/RequestManagerTest.php
@@ -33,7 +33,8 @@ class RequestManagerTest extends TestCase
         $request = new Request(
             '/foo/endpoint',
             RequestMethodInterface::METHOD_PUT,
-            ['foo' => 'bar', 'list' => ['lorem' => 'ipsum', 'dolor' => 333]]
+            ['foo' => 'bar', 'list' => ['lorem' => 'ipsum', 'dolor' => 333]],
+            'custom-request-id'
         );
 
         $matejResponse = $requestManager->sendRequest($request);
@@ -54,6 +55,7 @@ class RequestManagerTest extends TestCase
             $recordedRequests[0]->getBody()->__toString()
         );
         $this->assertSame(['application/json'], $recordedRequests[0]->getHeader('Content-Type'));
+        $this->assertSame(['custom-request-id'], $recordedRequests[0]->getHeader(RequestManager::REQUEST_ID_HEADER));
         $this->assertSame(
             Matej::CLIENT_ID . '/' . Matej::VERSION,
             $recordedRequests[0]->getHeader(RequestManager::CLIENT_VERSION_HEADER)[0]

--- a/tests/Http/ResponseDecoderTest.php
+++ b/tests/Http/ResponseDecoderTest.php
@@ -24,17 +24,32 @@ class ResponseDecoderTest extends TestCase
     {
         $response = $this->createJsonResponseFromFile(__DIR__ . '/Fixtures/response-one-successful-command.json');
 
-        $output = $this->decoder->decode($response);
+        $decodedResponse = $this->decoder->decode($response);
 
-        $this->assertSame(1, $output->getNumberOfCommands());
-        $this->assertSame(1, $output->getNumberOfSuccessfulCommands());
-        $this->assertSame(0, $output->getNumberOfFailedCommands());
-        $this->assertSame(0, $output->getNumberOfSkippedCommands());
+        $this->assertSame(1, $decodedResponse->getNumberOfCommands());
+        $this->assertSame(1, $decodedResponse->getNumberOfSuccessfulCommands());
+        $this->assertSame(0, $decodedResponse->getNumberOfFailedCommands());
+        $this->assertSame(0, $decodedResponse->getNumberOfSkippedCommands());
+        $this->assertNull($decodedResponse->getResponseId());
 
-        $commandResponses = $output->getCommandResponses();
+        $commandResponses = $decodedResponse->getCommandResponses();
         $this->assertCount(1, $commandResponses);
         $this->assertInstanceOf(CommandResponse::class, $commandResponses[0]);
         $this->assertSame(CommandResponse::STATUS_OK, $commandResponses[0]->getStatus());
+    }
+
+    /** @test */
+    public function shouldDecodeResponseId(): void
+    {
+        $response = new Response(
+            StatusCodeInterface::STATUS_OK,
+            [RequestManager::RESPONSE_ID_HEADER => 'received-response-id', 'Content-Type' => 'application/json'],
+            file_get_contents(__DIR__ . '/Fixtures/response-one-successful-command.json')
+        );
+
+        $decodedResponse = $this->decoder->decode($response);
+
+        $this->assertSame('received-response-id', $decodedResponse->getResponseId());
     }
 
     /** @test */
@@ -42,14 +57,14 @@ class ResponseDecoderTest extends TestCase
     {
         $response = $this->createJsonResponseFromFile(__DIR__ . '/Fixtures/response-item-properties.json');
 
-        $output = $this->decoder->decode($response);
+        $decodedResponse = $this->decoder->decode($response);
 
-        $this->assertSame(3, $output->getNumberOfCommands());
-        $this->assertSame(2, $output->getNumberOfSuccessfulCommands());
-        $this->assertSame(1, $output->getNumberOfFailedCommands());
-        $this->assertSame(0, $output->getNumberOfSkippedCommands());
+        $this->assertSame(3, $decodedResponse->getNumberOfCommands());
+        $this->assertSame(2, $decodedResponse->getNumberOfSuccessfulCommands());
+        $this->assertSame(1, $decodedResponse->getNumberOfFailedCommands());
+        $this->assertSame(0, $decodedResponse->getNumberOfSkippedCommands());
 
-        $commandResponses = $output->getCommandResponses();
+        $commandResponses = $decodedResponse->getCommandResponses();
         $this->assertCount(3, $commandResponses);
         $this->assertContainsOnlyInstancesOf(CommandResponse::class, $commandResponses);
         $this->assertSame(CommandResponse::STATUS_OK, $commandResponses[0]->getStatus());

--- a/tests/IntegrationTests/MatejTest.php
+++ b/tests/IntegrationTests/MatejTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\IntegrationTests;
+
+use Lmc\Matej\Model\Command\Sorting;
+
+class MatejTest extends IntegrationTestCase
+{
+    /** @test */
+    public function shouldReceiveRequestIdInResponse(): void
+    {
+        $requestId = uniqid('integration-test-php-client-request-id');
+
+        $response = $this->createMatejInstance()
+            ->request()
+            ->sorting(Sorting::create('integration-test-php-client-user-id-A', ['itemA', 'itemB']))
+            ->setRequestId($requestId)
+            ->send();
+
+        $this->assertSame($requestId, $response->getResponseId());
+    }
+}

--- a/tests/Model/RequestTest.php
+++ b/tests/Model/RequestTest.php
@@ -20,5 +20,16 @@ class RequestTest extends TestCase
         $this->assertSame($path, $request->getPath());
         $this->assertSame($method, $request->getMethod());
         $this->assertSame($data, $request->getData());
+
+        // no custom request id was set => random UUID v4 was generated
+        $this->assertSame(36, mb_strlen($request->getRequestId()));
+    }
+
+    /** @test */
+    public function shouldStoreCustomRequestId(): void
+    {
+        $request = new Request('/foo', RequestMethodInterface::METHOD_GET, [], 'custom-request-id');
+
+        $this->assertSame('custom-request-id', $request->getRequestId());
     }
 }

--- a/tests/Model/ResponseTest.php
+++ b/tests/Model/ResponseTest.php
@@ -5,6 +5,10 @@ namespace Lmc\Matej\Model;
 use Lmc\Matej\Exception\ResponseDecodingException;
 use Lmc\Matej\TestCase;
 
+/**
+ * @covers \Lmc\Matej\Model\Response
+ * @covers \Lmc\Matej\Exception\ResponseDecodingException
+ */
 class ResponseTest extends TestCase
 {
     /**
@@ -18,12 +22,14 @@ class ResponseTest extends TestCase
         int $numberOfSkipped,
         array $commandResponses
     ): void {
+        $responseId = uniqid((string) time());
         $response = new Response(
             $numberOfCommands,
             $numberOfSuccessful,
             $numberOfFailed,
             $numberOfSkipped,
-            $commandResponses
+            $commandResponses,
+            $responseId
         );
 
         $this->assertSame($numberOfCommands, $response->getNumberOfCommands());
@@ -33,6 +39,8 @@ class ResponseTest extends TestCase
 
         $this->assertContainsOnlyInstancesOf(CommandResponse::class, $response->getCommandResponses());
         $this->assertCount(count($commandResponses), $response->getCommandResponses());
+
+        $this->assertSame($responseId, $response->getResponseId());
     }
 
     /**

--- a/tests/RequestBuilder/CampaignRequestBuilderTest.php
+++ b/tests/RequestBuilder/CampaignRequestBuilderTest.php
@@ -45,6 +45,8 @@ class CampaignRequestBuilderTest extends TestCase
         $builder->addSorting($sortingCommand1);
         $builder->addSortings([$sortingCommand2, $sortingCommand3]);
 
+        $builder->setRequestId('custom-request-id-foo');
+
         $request = $builder->build();
 
         $this->assertInstanceOf(Request::class, $request);
@@ -59,6 +61,8 @@ class CampaignRequestBuilderTest extends TestCase
         $this->assertContains($sortingCommand1, $requestData);
         $this->assertContains($sortingCommand2, $requestData);
         $this->assertContains($sortingCommand3, $requestData);
+
+        $this->assertSame('custom-request-id-foo', $request->getRequestId());
     }
 
     /** @test */

--- a/tests/RequestBuilder/EventsRequestBuilderTest.php
+++ b/tests/RequestBuilder/EventsRequestBuilderTest.php
@@ -51,6 +51,8 @@ class EventsRequestBuilderTest extends TestCase
         $builder->addUserMerge($userMergeCommand1);
         $builder->addUserMerges([$userMergeCommand2, $userMergeCommand3]);
 
+        $builder->setRequestId('custom-request-id-foo');
+
         $request = $builder->build();
 
         $this->assertInstanceOf(Request::class, $request);
@@ -68,6 +70,8 @@ class EventsRequestBuilderTest extends TestCase
         $this->assertContains($userMergeCommand1, $requestData);
         $this->assertContains($userMergeCommand2, $requestData);
         $this->assertContains($userMergeCommand3, $requestData);
+
+        $this->assertSame('custom-request-id-foo', $request->getRequestId());
     }
 
     /** @test */

--- a/tests/RequestBuilder/ItemPropertiesSetupRequestBuilderTest.php
+++ b/tests/RequestBuilder/ItemPropertiesSetupRequestBuilderTest.php
@@ -41,6 +41,8 @@ class ItemPropertiesSetupRequestBuilderTest extends TestCase
         $builder->addProperty($command1);
         $builder->addProperties([$command2, $command3]);
 
+        $builder->setRequestId('custom-request-id-foo');
+
         $request = $builder->build();
 
         $this->assertInstanceOf(Request::class, $request);
@@ -50,6 +52,8 @@ class ItemPropertiesSetupRequestBuilderTest extends TestCase
         $this->assertSame($command1, $request->getData()[0]);
         $this->assertSame($command2, $request->getData()[1]);
         $this->assertSame($command3, $request->getData()[2]);
+
+        $this->assertSame('custom-request-id-foo', $request->getRequestId());
     }
 
     /**

--- a/tests/RequestBuilder/RecommendationRequestBuilderTest.php
+++ b/tests/RequestBuilder/RecommendationRequestBuilderTest.php
@@ -31,6 +31,8 @@ class RecommendationRequestBuilderTest extends TestCase
         $userMergeCommand = UserMerge::mergeFromSourceToTargetUser('sourceId1', 'userId1');
         $builder->setUserMerge($userMergeCommand);
 
+        $builder->setRequestId('custom-request-id-foo');
+
         $request = $builder->build();
 
         $this->assertInstanceOf(Request::class, $request);
@@ -42,6 +44,8 @@ class RecommendationRequestBuilderTest extends TestCase
         $this->assertSame($interactionCommand, $requestData[0]);
         $this->assertSame($userMergeCommand, $requestData[1]);
         $this->assertSame($recommendationsCommand, $requestData[2]);
+
+        $this->assertSame('custom-request-id-foo', $request->getRequestId());
     }
 
     /** @test */

--- a/tests/RequestBuilder/SortingRequestBuilderTest.php
+++ b/tests/RequestBuilder/SortingRequestBuilderTest.php
@@ -31,6 +31,8 @@ class SortingRequestBuilderTest extends TestCase
         $userMergeCommand = UserMerge::mergeFromSourceToTargetUser('sourceId1', 'userId1');
         $builder->setUserMerge($userMergeCommand);
 
+        $builder->setRequestId('custom-request-id-foo');
+
         $request = $builder->build();
 
         $this->assertInstanceOf(Request::class, $request);
@@ -42,6 +44,8 @@ class SortingRequestBuilderTest extends TestCase
         $this->assertSame($interactionCommand, $requestData[0]);
         $this->assertSame($userMergeCommand, $requestData[1]);
         $this->assertSame($sortingCommand, $requestData[2]);
+
+        $this->assertSame('custom-request-id-foo', $request->getRequestId());
     }
 
     /** @test */


### PR DESCRIPTION
Useful for debugging concrete requests. See #18 and RAD-653.


Mark request with custom ID to make it traceable by R&D team:
```
$response = $matej->request()
    ->recommendation($recommendation)
    ->setRequestId('this-is-request-id-i-want-to-trace')
    ->send();
```

Or log response ID even if no custom was send with the request:

```
$response = $matej->request()
    ->recommendation($recommendation)
    ->send();

if (/* I don't like something in the response */) {
    $this->logger->error($response->getResponseId()); // there will be some random response ID, which you can ask R&D team to debug
}
```
