### PR TITLE
Add endpoint for getting item properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+### Added
+- Endpoint to get all defined item properties in the Matej database (`$matej->request()->getItemProperties()`).
 
 ## 1.0.0 - 2017-12-05
 ### Added

--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ $response = $matej->request()
     ->addProperty(ItemPropertySetup::string('title'))
     ->send();
 
+// Get list of item properties that are defined in matej
+$response = $matej->request()
+    ->getItemProperties()
+    ->send();
+
 // Delete item property from database:
 $response = $matej->request()
     ->deleteItemProperties()

--- a/src/Model/Request.php
+++ b/src/Model/Request.php
@@ -18,7 +18,7 @@ class Request
     /** @var string */
     private $requestId;
 
-    public function __construct(string $path, string $method, array $data, string $requestId = null)
+    public function __construct(string $path, string $method, array $data = [], string $requestId = null)
     {
         $this->path = $path;
         $this->method = $method;

--- a/src/RequestBuilder/ItemPropertiesGetRequestBuilder.php
+++ b/src/RequestBuilder/ItemPropertiesGetRequestBuilder.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\RequestBuilder;
+
+use Fig\Http\Message\RequestMethodInterface;
+use Lmc\Matej\Model\Request;
+
+class ItemPropertiesGetRequestBuilder extends AbstractRequestBuilder
+{
+    protected const ENDPOINT_PATH = '/item-properties';
+
+    public function build(): Request
+    {
+        return new Request(self::ENDPOINT_PATH, RequestMethodInterface::METHOD_GET, [], $this->requestId);
+    }
+}

--- a/src/RequestBuilder/RequestBuilderFactory.php
+++ b/src/RequestBuilder/RequestBuilderFactory.php
@@ -19,6 +19,11 @@ class RequestBuilderFactory
         $this->requestManager = $requestManager;
     }
 
+    public function getItemProperties(): ItemPropertiesGetRequestBuilder
+    {
+        return $this->createConfiguredBuilder(ItemPropertiesGetRequestBuilder::class);
+    }
+
     /**
      * Define new properties into the database. Those properties will be created and subsequently accepted by Matej.
      *

--- a/tests/integration/RequestBuilder/ItemPropertiesGetRequestBuilderTest.php
+++ b/tests/integration/RequestBuilder/ItemPropertiesGetRequestBuilderTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\IntegrationTests\RequestBuilder;
+
+use Lmc\Matej\IntegrationTests\IntegrationTestCase;
+
+/**
+ * @covers \Lmc\Matej\RequestBuilder\ItemPropertiesGetRequestBuilder
+ */
+class ItemPropertiesGetRequestBuilderTest extends IntegrationTestCase
+{
+    /** @test */
+    public function shouldGetListOfPropertiesFromMatej(): void
+    {
+        $response = $this->createMatejInstance()
+            ->request()
+            ->getItemProperties()
+            ->send();
+
+        $this->assertResponseCommandStatuses($response, 'OK');
+    }
+}

--- a/tests/unit/RequestBuilder/ItemPropertiesGetRequestBuilderTest.php
+++ b/tests/unit/RequestBuilder/ItemPropertiesGetRequestBuilderTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\RequestBuilder;
+
+use Fig\Http\Message\RequestMethodInterface;
+use Lmc\Matej\Exception\LogicException;
+use Lmc\Matej\Http\RequestManager;
+use Lmc\Matej\Model\Request;
+use Lmc\Matej\Model\Response;
+use Lmc\Matej\UnitTestCase;
+
+/**
+ * @covers \Lmc\Matej\RequestBuilder\ItemPropertiesGetRequestBuilder
+ */
+class ItemPropertiesGetRequestBuilderTest extends UnitTestCase
+{
+    /** @test */
+    public function shouldBuildRequestWithCommands(): void
+    {
+        $builder = new ItemPropertiesGetRequestBuilder();
+        $builder->setRequestId('custom-request-id-foo');
+
+        $request = $builder->build();
+
+        $this->assertInstanceOf(Request::class, $request);
+        $this->assertSame(RequestMethodInterface::METHOD_GET, $request->getMethod());
+        $this->assertSame('/item-properties', $request->getPath());
+        $this->assertEmpty($request->getData());
+        $this->assertSame('custom-request-id-foo', $request->getRequestId());
+    }
+
+    /** @test */
+    public function shouldThrowExceptionWhenSendingCommandsWithoutRequestManager(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Instance of RequestManager must be set to request builder');
+
+        $builder = new ItemPropertiesGetRequestBuilder();
+        $builder->send();
+    }
+
+    /** @test */
+    public function shouldSendRequestViaRequestManager(): void
+    {
+        $requestManagerMock = $this->createMock(RequestManager::class);
+        $requestManagerMock->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->isInstanceOf(Request::class))
+            ->willReturn(new Response(0, 0, 0, 0));
+
+        $builder = new ItemPropertiesGetRequestBuilder();
+        $builder->setRequestManager($requestManagerMock);
+        $builder->send();
+    }
+}

--- a/tests/unit/RequestBuilder/RequestBuilderFactoryTest.php
+++ b/tests/unit/RequestBuilder/RequestBuilderFactoryTest.php
@@ -69,6 +69,7 @@ class RequestBuilderFactoryTest extends TestCase
         $userRecommendation = UserRecommendation::create('user-id', 1, 'test-scenario', 0.5, 3600);
 
         return [
+            ['getItemProperties', ItemPropertiesGetRequestBuilder::class, $voidInit],
             ['setupItemProperties', ItemPropertiesSetupRequestBuilder::class, $itemPropertiesSetupInit],
             ['deleteItemProperties', ItemPropertiesSetupRequestBuilder::class, $itemPropertiesSetupInit],
             ['events', EventsRequestBuilder::class, $eventInit],


### PR DESCRIPTION
Depends on matej's deploy of RAD-720

Depends on #46 - **before merging, change base of PR**

Implements `GET /item-properties`