### PR TITLE
Hardcode http query argument separator so that URL assembling works even on non-standard environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Custom request ID could be passed to a request (via `setRequestId()` method of request builders). If none is set, random request ID is generated.
 - Response ID could be read from the response via `getRequestId()` method of the Response object.
 
+### Fixed
+- URL assembling was not working on systems with non-standard setting of `arg_separator.output` PHP directive.
+
 ## 0.10.0 - 2017-11-30
 ### Changed
 - All exceptions now implement `MatejExceptionInterface` instead of subclassing `AbstractMatejException`.

--- a/src/Http/HmacAuthentication.php
+++ b/src/Http/HmacAuthentication.php
@@ -53,7 +53,7 @@ class HmacAuthentication implements Authentication
     {
         $uri = $request->getUri();
 
-        $query = http_build_query($params);
+        $query = http_build_query($params, '', '&');
         $uri = $uri->withQuery($query);
 
         return $request->withUri($uri);


### PR DESCRIPTION
Its unexpected, but yes, there are environments where `arg_separator.output` is not set to `&` 🙃 .