### PR TITLE
Add syntax sugar for Sorting and Recommendation endpoints (RAD-746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Changed
 - Validate max. 1000 commands are added to `campaign()`, `events()`, `setupItemProperties()` and `deleteItemProperties()` requests (in accordance with Matej batch API limit).
+- `Response` now contains `getCommandResponse(int $index)` to access individual command responses.
+- `sorting()->send()` request now returns `SortingResponse` instance, which provides semantic access to data of the response (ie `->getSorting()`).
+- `recommendation()->send()` request now returns `RecommendationResponse` instance, which provides semantic access to data of the response (ie. `->getRecommendation()`).
+- `getItemProperties()->send()` request now returns `ItemPropertiesListResponse` instance, which provides semantic access to data of the response (ie. `->getData()`).
 
 ## 1.0.0 - 2017-12-05
 ### Added

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ foreach ($response->getCommandResponses() as $commandResponse) {
 }
 ```
 
+[Recommendation](#recommendations-for-single-user), [Sorting](#request-item-sorting-for-single-user)
+and [Item Properties](#item-properties-setup-to-setup-you-matej-database) endpoints have syntax sugar,
+which makes processing responses easier. See below for detailed examples.
+
 ### Item properties setup (to setup you Matej database)
 
 ```php
@@ -95,6 +99,8 @@ $response = $matej->request()
 $response = $matej->request()
     ->getItemProperties()
     ->send();
+
+$properties = $response->getData();
 
 // Delete item property from database:
 $response = $matej->request()
@@ -144,6 +150,8 @@ $response = $matej->request()
     ->setInteraction(Interaction::purchase('user-id', 'item-id')) // optional
     ->setUserMerge(UserMerge::mergeInto('user-id', 'source-id')) // optional
     ->send();
+
+$recommendations = $response->getRecommendation()->getData();
 ```
 
 You can also set more granular options of the recommendation command:
@@ -157,6 +165,20 @@ $recommendation->setFilters(['valid_to >= NOW']) // Note this filter is present 
 $response = $matej->request()
     ->recommendation($recommendation)
     ->send();
+```
+
+From `$response`, you can also access rest of the data:
+
+```php
+$response = $matej->request()
+    ->recommendation($recommendation)
+    ->send();
+
+echo $response->getInteraction()->getStatus();    // SKIPPED
+echo $response->getUserMerge()->getStatus();      // SKIPPED
+echo $response->getRecommendation()->getStatus(); // OK
+
+$recommendations = $response->getRecommendation()->getData();
 ```
 
 ### Request item sorting for single user
@@ -173,6 +195,21 @@ $response =  $matej->request()
     ->setUserMerge(UserMerge::mergeInto('user-id', 'source-id')) // optional
     ->send();
 
+$sortedItems = $response->getSorting()->getData();
+```
+
+From `$response`, you can also access rest of the data:
+
+```php
+$response = $matej->request()
+    ->sorting($sorting)
+    ->send();
+
+echo $response->getInteraction()->getStatus(); // SKIPPED
+echo $response->getUserMerge()->getStatus();   // SKIPPED
+echo $response->getSorting()->getStatus();     // OK
+
+$sortedData = $response->getSorting()->getData();
 ```
 
 ### Request batch of recommendations/item sortings

--- a/src/Exception/LogicException.php
+++ b/src/Exception/LogicException.php
@@ -21,4 +21,9 @@ class LogicException extends \LogicException implements MatejExceptionInterface
 
         return new self($message);
     }
+
+    public static function forClassNotExtendingOtherClass($class, $wantedClass)
+    {
+        return new self(sprintf('Class %s has to be instance or subclass of %s.', $class, $wantedClass));
+    }
 }

--- a/src/Http/RequestManager.php
+++ b/src/Http/RequestManager.php
@@ -52,7 +52,7 @@ class RequestManager
 
         $httpResponse = $client->sendRequest($httpRequest);
 
-        return $this->getResponseDecoder()->decode($httpResponse);
+        return $this->getResponseDecoder()->decode($httpResponse, $request->getResponseClass());
     }
 
     /** @codeCoverageIgnore */

--- a/src/Http/ResponseDecoder.php
+++ b/src/Http/ResponseDecoder.php
@@ -8,7 +8,7 @@ use Psr\Http\Message\ResponseInterface;
 
 class ResponseDecoder implements ResponseDecoderInterface
 {
-    public function decode(ResponseInterface $httpResponse): Response
+    public function decode(ResponseInterface $httpResponse, string $responseClass = Response::class): Response
     {
         $responseData = json_decode($httpResponse->getBody()->getContents());
 
@@ -22,7 +22,7 @@ class ResponseDecoder implements ResponseDecoderInterface
 
         $responseId = $httpResponse->getHeader(RequestManager::RESPONSE_ID_HEADER)[0] ?? null;
 
-        return new Response(
+        return new $responseClass(
             (int) $responseData->commands->number_of_commands,
             (int) $responseData->commands->number_of_successful_commands,
             (int) $responseData->commands->number_of_failed_commands,

--- a/src/Http/ResponseDecoderInterface.php
+++ b/src/Http/ResponseDecoderInterface.php
@@ -7,5 +7,5 @@ use Psr\Http\Message\ResponseInterface;
 
 interface ResponseDecoderInterface
 {
-    public function decode(ResponseInterface $httpResponse): Response;
+    public function decode(ResponseInterface $httpResponse, string $responseClass = Response::class): Response;
 }

--- a/src/Model/Assertion.php
+++ b/src/Model/Assertion.php
@@ -3,6 +3,7 @@
 namespace Lmc\Matej\Model;
 
 use Lmc\Matej\Exception\DomainException;
+use Lmc\Matej\Exception\LogicException;
 use Lmc\Matej\Model\Command\AbstractCommand;
 
 /**
@@ -37,13 +38,28 @@ class Assertion extends \Assert\Assertion
      *
      * @param AbstractCommand[] $commands
      */
-    public static function batchSize(array $commands)
+    public static function batchSize(array $commands): bool
     {
         static::lessOrEqualThan(
             count($commands),
             self::MAX_BATCH_SIZE,
             'Request contains %s commands, but at most %s is allowed in one request.'
         );
+
+        return true;
+    }
+
+    /**
+     * Assert that provided classname is an instance or subclass of Response
+     */
+    public static function isResponseClass(string $wantedClass): bool
+    {
+        if (
+            !is_a($wantedClass, Response::class, true) &&
+            !is_subclass_of($wantedClass, Response::class)
+        ) {
+            throw LogicException::forClassNotExtendingOtherClass($wantedClass, Response::class);
+        }
 
         return true;
     }

--- a/src/Model/Request.php
+++ b/src/Model/Request.php
@@ -17,13 +17,16 @@ class Request
     private $data;
     /** @var string */
     private $requestId;
+    /** @var string */
+    private $responseClass;
 
-    public function __construct(string $path, string $method, array $data = [], string $requestId = null)
+    public function __construct(string $path, string $method, array $data = [], string $requestId = null, string $responseClass = Response::class)
     {
         $this->path = $path;
         $this->method = $method;
         $this->data = $data;
         $this->requestId = $requestId ?? Uuid::uuid4()->toString();
+        $this->setResponseClass($responseClass);
     }
 
     public function getPath(): string
@@ -44,5 +47,19 @@ class Request
     public function getRequestId(): string
     {
         return $this->requestId;
+    }
+
+    public function getResponseClass(): string
+    {
+        return $this->responseClass;
+    }
+
+    private function setResponseClass(string $class): self
+    {
+        Assertion::isResponseClass($class);
+
+        $this->responseClass = $class;
+
+        return $this;
     }
 }

--- a/src/Model/Response.php
+++ b/src/Model/Response.php
@@ -79,6 +79,14 @@ class Response
     }
 
     /**
+     * Return individual command response by its index (0 indexed)
+     */
+    public function getCommandResponse(int $index): CommandResponse
+    {
+        return $this->commandResponses[$index];
+    }
+
+    /**
      * Each Command which was part of request batch has here corresponding CommandResponse - on the same index on which
      * the Command was added to the request batch.
      *

--- a/src/Model/Response/ItemPropertiesListResponse.php
+++ b/src/Model/Response/ItemPropertiesListResponse.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model\Response;
+
+use Lmc\Matej\Model\Response;
+
+class ItemPropertiesListResponse extends Response
+{
+    public function isSuccessful(): bool
+    {
+        return $this->getCommandResponse(0)->isSuccessful();
+    }
+
+    public function getData(): array
+    {
+        return $this->getCommandResponse(0)->getData();
+    }
+
+    public function getMessage(): string
+    {
+        return $this->getCommandResponse(0)->getMessage();
+    }
+
+    public function getStatus(): string
+    {
+        return $this->getCommandResponse(0)->getStatus();
+    }
+}

--- a/src/Model/Response/RecommendationsResponse.php
+++ b/src/Model/Response/RecommendationsResponse.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model\Response;
+
+use Lmc\Matej\Model\CommandResponse;
+use Lmc\Matej\Model\Response;
+
+class RecommendationsResponse extends Response
+{
+    public function getInteraction(): CommandResponse
+    {
+        return $this->getCommandResponse(0);
+    }
+
+    public function getUserMerge(): CommandResponse
+    {
+        return $this->getCommandResponse(1);
+    }
+
+    public function getRecommendation(): CommandResponse
+    {
+        return $this->getCommandResponse(2);
+    }
+}

--- a/src/Model/Response/SortingResponse.php
+++ b/src/Model/Response/SortingResponse.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model\Response;
+
+use Lmc\Matej\Model\CommandResponse;
+use Lmc\Matej\Model\Response;
+
+class SortingResponse extends Response
+{
+    public function getInteraction(): CommandResponse
+    {
+        return $this->getCommandResponse(0);
+    }
+
+    public function getUserMerge(): CommandResponse
+    {
+        return $this->getCommandResponse(1);
+    }
+
+    public function getSorting(): CommandResponse
+    {
+        return $this->getCommandResponse(2);
+    }
+}

--- a/src/RequestBuilder/ItemPropertiesGetRequestBuilder.php
+++ b/src/RequestBuilder/ItemPropertiesGetRequestBuilder.php
@@ -4,13 +4,23 @@ namespace Lmc\Matej\RequestBuilder;
 
 use Fig\Http\Message\RequestMethodInterface;
 use Lmc\Matej\Model\Request;
+use Lmc\Matej\Model\Response\ItemPropertiesListResponse;
 
+/**
+ * @method ItemPropertiesListResponse send()
+ */
 class ItemPropertiesGetRequestBuilder extends AbstractRequestBuilder
 {
     protected const ENDPOINT_PATH = '/item-properties';
 
     public function build(): Request
     {
-        return new Request(self::ENDPOINT_PATH, RequestMethodInterface::METHOD_GET, [], $this->requestId);
+        return new Request(
+            self::ENDPOINT_PATH,
+            RequestMethodInterface::METHOD_GET,
+            [],
+            $this->requestId,
+            ItemPropertiesListResponse::class
+        );
     }
 }

--- a/src/RequestBuilder/RecommendationRequestBuilder.php
+++ b/src/RequestBuilder/RecommendationRequestBuilder.php
@@ -8,7 +8,11 @@ use Lmc\Matej\Model\Command\Interaction;
 use Lmc\Matej\Model\Command\UserMerge;
 use Lmc\Matej\Model\Command\UserRecommendation;
 use Lmc\Matej\Model\Request;
+use Lmc\Matej\Model\Response\RecommendationsResponse;
 
+/**
+ * @method RecommendationsResponse send()
+ */
 class RecommendationRequestBuilder extends AbstractRequestBuilder
 {
     protected const ENDPOINT_PATH = '/recommendations';
@@ -47,7 +51,8 @@ class RecommendationRequestBuilder extends AbstractRequestBuilder
             self::ENDPOINT_PATH,
             RequestMethodInterface::METHOD_POST,
             [$this->interactionCommand, $this->userMergeCommand, $this->userRecommendationCommand],
-            $this->requestId
+            $this->requestId,
+            RecommendationsResponse::class
         );
     }
 

--- a/src/RequestBuilder/SortingRequestBuilder.php
+++ b/src/RequestBuilder/SortingRequestBuilder.php
@@ -8,7 +8,11 @@ use Lmc\Matej\Model\Command\Interaction;
 use Lmc\Matej\Model\Command\Sorting;
 use Lmc\Matej\Model\Command\UserMerge;
 use Lmc\Matej\Model\Request;
+use Lmc\Matej\Model\Response\SortingResponse;
 
+/**
+ * @method SortingResponse send()
+ */
 class SortingRequestBuilder extends AbstractRequestBuilder
 {
     protected const ENDPOINT_PATH = '/sorting';
@@ -47,7 +51,8 @@ class SortingRequestBuilder extends AbstractRequestBuilder
             self::ENDPOINT_PATH,
             RequestMethodInterface::METHOD_POST,
             [$this->interactionCommand, $this->userMergeCommand, $this->sortingCommand],
-            $this->requestId
+            $this->requestId,
+            SortingResponse::class
         );
     }
 

--- a/tests/integration/RequestBuilder/ItemPropertiesGetRequestBuilderTest.php
+++ b/tests/integration/RequestBuilder/ItemPropertiesGetRequestBuilderTest.php
@@ -3,8 +3,10 @@
 namespace Lmc\Matej\IntegrationTests\RequestBuilder;
 
 use Lmc\Matej\IntegrationTests\IntegrationTestCase;
+use Lmc\Matej\Model\Response\ItemPropertiesListResponse;
 
 /**
+ * @covers \Lmc\Matej\Model\Response\ItemPropertiesListResponse
  * @covers \Lmc\Matej\RequestBuilder\ItemPropertiesGetRequestBuilder
  */
 class ItemPropertiesGetRequestBuilderTest extends IntegrationTestCase
@@ -18,5 +20,10 @@ class ItemPropertiesGetRequestBuilderTest extends IntegrationTestCase
             ->send();
 
         $this->assertResponseCommandStatuses($response, 'OK');
+        $this->assertInstanceOf(ItemPropertiesListResponse::class, $response);
+        $this->assertTrue($response->isSuccessful());
+        $this->assertSame('', $response->getMessage());
+        $this->assertSame('OK', $response->getStatus());
+        $this->assertInternalType('array', $response->getData());
     }
 }

--- a/tests/integration/RequestBuilder/RecommendationRequestBuilderTest.php
+++ b/tests/integration/RequestBuilder/RecommendationRequestBuilderTest.php
@@ -6,8 +6,11 @@ use Lmc\Matej\IntegrationTests\IntegrationTestCase;
 use Lmc\Matej\Model\Command\Interaction;
 use Lmc\Matej\Model\Command\UserMerge;
 use Lmc\Matej\Model\Command\UserRecommendation;
+use Lmc\Matej\Model\CommandResponse;
+use Lmc\Matej\Model\Response\RecommendationsResponse;
 
 /**
+ * @covers \Lmc\Matej\Model\Response\RecommendationsResponse
  * @covers \Lmc\Matej\RequestBuilder\RecommendationRequestBuilder
  */
 class RecommendationRequestBuilderTest extends IntegrationTestCase
@@ -20,7 +23,9 @@ class RecommendationRequestBuilderTest extends IntegrationTestCase
             ->recommendation($this->createRecommendationCommand())
             ->send();
 
+        $this->assertInstanceOf(RecommendationsResponse::class, $response);
         $this->assertResponseCommandStatuses($response, 'SKIPPED', 'SKIPPED', 'OK');
+        $this->assertShorthandResponse($response, 'SKIPPED', 'SKIPPED', 'OK');
     }
 
     /** @test */
@@ -33,7 +38,9 @@ class RecommendationRequestBuilderTest extends IntegrationTestCase
             ->setInteraction(Interaction::bookmark('user-a', 'item-a'))
             ->send();
 
+        $this->assertInstanceOf(RecommendationsResponse::class, $response);
         $this->assertResponseCommandStatuses($response, 'OK', 'OK', 'OK');
+        $this->assertShorthandResponse($response, 'OK', 'OK', 'OK');
     }
 
     private function createRecommendationCommand(): UserRecommendation
@@ -45,5 +52,15 @@ class RecommendationRequestBuilderTest extends IntegrationTestCase
             0.50,
             3600
         );
+    }
+
+    private function assertShorthandResponse(RecommendationsResponse $response, $interactionStatus, $userMergeStatus, $recommendationStatus): void
+    {
+        $this->assertInstanceOf(CommandResponse::class, $response->getInteraction());
+        $this->assertInstanceOf(CommandResponse::class, $response->getUserMerge());
+        $this->assertInstanceOf(CommandResponse::class, $response->getRecommendation());
+        $this->assertSame($interactionStatus, $response->getInteraction()->getStatus());
+        $this->assertSame($userMergeStatus, $response->getUserMerge()->getStatus());
+        $this->assertSame($recommendationStatus, $response->getRecommendation()->getStatus());
     }
 }

--- a/tests/integration/RequestBuilder/SortingRequestTest.php
+++ b/tests/integration/RequestBuilder/SortingRequestTest.php
@@ -6,8 +6,11 @@ use Lmc\Matej\IntegrationTests\IntegrationTestCase;
 use Lmc\Matej\Model\Command\Interaction;
 use Lmc\Matej\Model\Command\Sorting;
 use Lmc\Matej\Model\Command\UserMerge;
+use Lmc\Matej\Model\CommandResponse;
+use Lmc\Matej\Model\Response\SortingResponse;
 
 /**
+ * @covers \Lmc\Matej\Model\Response\SortingResponse
  * @covers \Lmc\Matej\RequestBuilder\SortingRequestBuilder
  */
 class SortingRequestTest extends IntegrationTestCase
@@ -20,7 +23,9 @@ class SortingRequestTest extends IntegrationTestCase
             ->sorting(Sorting::create('user-a', ['itemA', 'itemB', 'itemC']))
             ->send();
 
+        $this->assertInstanceOf(SortingResponse::class, $response);
         $this->assertResponseCommandStatuses($response, 'SKIPPED', 'SKIPPED', 'OK');
+        $this->assertShorthandResponse($response, 'SKIPPED', 'SKIPPED', 'OK');
     }
 
     /** @test */
@@ -33,6 +38,18 @@ class SortingRequestTest extends IntegrationTestCase
             ->setInteraction(Interaction::bookmark('user-a', 'item-a'))
             ->send();
 
+        $this->assertInstanceOf(SortingResponse::class, $response);
         $this->assertResponseCommandStatuses($response, 'OK', 'OK', 'OK');
+        $this->assertShorthandResponse($response, 'OK', 'OK', 'OK');
+    }
+
+    private function assertShorthandResponse(SortingResponse $response, $interactionStatus, $userMergeStatus, $sortingStatus): void
+    {
+        $this->assertInstanceOf(CommandResponse::class, $response->getInteraction());
+        $this->assertInstanceOf(CommandResponse::class, $response->getUserMerge());
+        $this->assertInstanceOf(CommandResponse::class, $response->getSorting());
+        $this->assertSame($interactionStatus, $response->getInteraction()->getStatus());
+        $this->assertSame($userMergeStatus, $response->getUserMerge()->getStatus());
+        $this->assertSame($sortingStatus, $response->getSorting()->getStatus());
     }
 }

--- a/tests/unit/Model/AssertionTest.php
+++ b/tests/unit/Model/AssertionTest.php
@@ -3,6 +3,7 @@
 namespace Lmc\Matej\Model;
 
 use Lmc\Matej\Exception\DomainException;
+use Lmc\Matej\Exception\LogicException;
 use Lmc\Matej\Model\Command\ItemPropertySetup;
 use PHPUnit\Framework\TestCase;
 
@@ -122,5 +123,28 @@ class AssertionTest extends TestCase
             [1001],
             [2000],
         ];
+    }
+
+    /** @test */
+    public function shouldAssertValidResponseClass(): void
+    {
+        $inheritedObject = new class(0, 0, 0, 0) extends Response {
+        };
+
+        $this->assertTrue(Assertion::isResponseClass(Response::class));
+        $this->assertTrue(Assertion::isResponseClass(get_class($inheritedObject)));
+    }
+
+    /** @test */
+    public function shouldAssertInvalidResponseClass(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Class %s has to be instance or subclass of %s.',
+            \stdClass::class,
+            Response::class
+        ));
+
+        Assertion::isResponseClass(\stdClass::class);
     }
 }

--- a/tests/unit/Model/RequestTest.php
+++ b/tests/unit/Model/RequestTest.php
@@ -3,6 +3,8 @@
 namespace Lmc\Matej\Model;
 
 use Fig\Http\Message\RequestMethodInterface;
+use Lmc\Matej\Exception\LogicException;
+use Lmc\Matej\Model\Response\SortingResponse;
 use Lmc\Matej\UnitTestCase;
 
 class RequestTest extends UnitTestCase
@@ -31,5 +33,32 @@ class RequestTest extends UnitTestCase
         $request = new Request('/foo', RequestMethodInterface::METHOD_GET, [], 'custom-request-id');
 
         $this->assertSame('custom-request-id', $request->getRequestId());
+    }
+
+    /** @test */
+    public function shouldStoreResponseClass(): void
+    {
+        $request = new Request(
+            '/foo',
+            RequestMethodInterface::METHOD_GET,
+            [],
+            null,
+            SortingResponse::class
+        );
+
+        $this->assertSame(SortingResponse::class, $request->getResponseClass());
+    }
+
+    /** @test */
+    public function shouldThrowExceptionWhenSettingInvalidResponseClass(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Class %s has to be instance or subclass of %s.',
+            \stdClass::class,
+            Response::class
+        ));
+
+        $request = new Request('/foo', RequestMethodInterface::METHOD_GET, [], null, \stdClass::class);
     }
 }

--- a/tests/unit/Model/Response/ItemPropertiesListResponseTest.php
+++ b/tests/unit/Model/Response/ItemPropertiesListResponseTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model\Response;
+
+use Lmc\Matej\Model\CommandResponse;
+use Lmc\Matej\UnitTestCase;
+
+class ItemPropertiesListResponseTest extends UnitTestCase
+{
+    /** @test */
+    public function shouldBeInstantiable(): void
+    {
+        $commandResponse = (object) [
+            'status' => CommandResponse::STATUS_OK,
+            'message' => 'MOCK_MESSAGE',
+            'data' => ['MOCK' => 'DATA'],
+        ];
+
+        $response = new ItemPropertiesListResponse(1, 1, 0, 0, [$commandResponse]);
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertSame(CommandResponse::STATUS_OK, $response->getStatus());
+        $this->assertSame('MOCK_MESSAGE', $response->getMessage());
+        $this->assertSame(['MOCK' => 'DATA'], $response->getData());
+    }
+}

--- a/tests/unit/Model/Response/RecommendationsResponseTest.php
+++ b/tests/unit/Model/Response/RecommendationsResponseTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model\Response;
+
+use Lmc\Matej\Model\CommandResponse;
+use Lmc\Matej\UnitTestCase;
+
+class RecommendationsResponseTest extends UnitTestCase
+{
+    /** @test */
+    public function shouldBeInstantiable(): void
+    {
+        $interactionCommandResponse = (object) [
+            'status' => CommandResponse::STATUS_OK,
+            'message' => 'MOCK_INTERACTION_MESSAGE',
+            'data' => ['MOCK' => 'INTERACTION'],
+        ];
+        $userMergeCommandResponse = (object) [
+            'status' => CommandResponse::STATUS_OK,
+            'message' => 'MOCK_USER_MERGE_MESSAGE',
+            'data' => ['MOCK' => 'USER_MERGE'],
+        ];
+        $recommendationCommandResponse = (object) [
+            'status' => CommandResponse::STATUS_OK,
+            'message' => 'MOCK_RECOMMENDATION_MESSAGE',
+            'data' => ['MOCK' => 'RECOMMENDATION'],
+        ];
+
+        $response = new RecommendationsResponse(3, 3, 0, 0, [$interactionCommandResponse, $userMergeCommandResponse, $recommendationCommandResponse]);
+
+        $this->assertTrue($response->getInteraction()->isSuccessful());
+        $this->assertTrue($response->getUserMerge()->isSuccessful());
+        $this->assertTrue($response->getRecommendation()->isSuccessful());
+
+        $this->assertSame(CommandResponse::STATUS_OK, $response->getInteraction()->getStatus());
+        $this->assertSame(CommandResponse::STATUS_OK, $response->getUserMerge()->getStatus());
+        $this->assertSame(CommandResponse::STATUS_OK, $response->getRecommendation()->getStatus());
+
+        $this->assertSame('MOCK_INTERACTION_MESSAGE', $response->getInteraction()->getMessage());
+        $this->assertSame(['MOCK' => 'INTERACTION'], $response->getInteraction()->getData());
+
+        $this->assertSame('MOCK_USER_MERGE_MESSAGE', $response->getUserMerge()->getMessage());
+        $this->assertSame(['MOCK' => 'USER_MERGE'], $response->getUserMerge()->getData());
+
+        $this->assertSame('MOCK_RECOMMENDATION_MESSAGE', $response->getRecommendation()->getMessage());
+        $this->assertSame(['MOCK' => 'RECOMMENDATION'], $response->getRecommendation()->getData());
+    }
+}

--- a/tests/unit/Model/Response/SortingResponseTest.php
+++ b/tests/unit/Model/Response/SortingResponseTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model\Response;
+
+use Lmc\Matej\Model\CommandResponse;
+use Lmc\Matej\UnitTestCase;
+
+class SortingResponseTest extends UnitTestCase
+{
+    /** @test */
+    public function shouldBeInstantiable(): void
+    {
+        $interactionCommandResponse = (object) [
+            'status' => CommandResponse::STATUS_OK,
+            'message' => 'MOCK_INTERACTION_MESSAGE',
+            'data' => ['MOCK' => 'INTERACTION'],
+        ];
+        $userMergeCommandResponse = (object) [
+            'status' => CommandResponse::STATUS_OK,
+            'message' => 'MOCK_USER_MERGE_MESSAGE',
+            'data' => ['MOCK' => 'USER_MERGE'],
+        ];
+        $sortingCommandReponse = (object) [
+            'status' => CommandResponse::STATUS_OK,
+            'message' => 'MOCK_SORTING_MESSAGE',
+            'data' => ['MOCK' => 'SORTING'],
+        ];
+
+        $response = new SortingResponse(3, 3, 0, 0, [$interactionCommandResponse, $userMergeCommandResponse, $sortingCommandReponse]);
+
+        $this->assertTrue($response->getInteraction()->isSuccessful());
+        $this->assertTrue($response->getUserMerge()->isSuccessful());
+        $this->assertTrue($response->getSorting()->isSuccessful());
+
+        $this->assertSame(CommandResponse::STATUS_OK, $response->getInteraction()->getStatus());
+        $this->assertSame(CommandResponse::STATUS_OK, $response->getUserMerge()->getStatus());
+        $this->assertSame(CommandResponse::STATUS_OK, $response->getSorting()->getStatus());
+
+        $this->assertSame('MOCK_INTERACTION_MESSAGE', $response->getInteraction()->getMessage());
+        $this->assertSame(['MOCK' => 'INTERACTION'], $response->getInteraction()->getData());
+
+        $this->assertSame('MOCK_USER_MERGE_MESSAGE', $response->getUserMerge()->getMessage());
+        $this->assertSame(['MOCK' => 'USER_MERGE'], $response->getUserMerge()->getData());
+
+        $this->assertSame('MOCK_SORTING_MESSAGE', $response->getSorting()->getMessage());
+        $this->assertSame(['MOCK' => 'SORTING'], $response->getSorting()->getData());
+    }
+}

--- a/tests/unit/Model/ResponseTest.php
+++ b/tests/unit/Model/ResponseTest.php
@@ -37,10 +37,13 @@ class ResponseTest extends UnitTestCase
         $this->assertSame($numberOfFailed, $response->getNumberOfFailedCommands());
         $this->assertSame($numberOfSkipped, $response->getNumberOfSkippedCommands());
 
-        $this->assertContainsOnlyInstancesOf(CommandResponse::class, $response->getCommandResponses());
-        $this->assertCount(count($commandResponses), $response->getCommandResponses());
-
         $this->assertSame($responseId, $response->getResponseId());
+
+        $this->assertCount(count($commandResponses), $response->getCommandResponses());
+        $this->assertContainsOnlyInstancesOf(CommandResponse::class, $response->getCommandResponses());
+        for ($i = 0; $i < count($commandResponses); $i++) {
+            $this->assertInstanceOf(CommandResponse::class, $response->getCommandResponse($i));
+        }
     }
 
     /**

--- a/tests/unit/RequestBuilder/RecommendationRequestBuilderTest.php
+++ b/tests/unit/RequestBuilder/RecommendationRequestBuilderTest.php
@@ -11,6 +11,7 @@ use Lmc\Matej\Model\Command\UserMerge;
 use Lmc\Matej\Model\Command\UserRecommendation;
 use Lmc\Matej\Model\Request;
 use Lmc\Matej\Model\Response;
+use Lmc\Matej\Model\Response\RecommendationsResponse;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -46,6 +47,7 @@ class RecommendationRequestBuilderTest extends TestCase
         $this->assertSame($recommendationsCommand, $requestData[2]);
 
         $this->assertSame('custom-request-id-foo', $request->getRequestId());
+        $this->assertSame(RecommendationsResponse::class, $request->getResponseClass());
     }
 
     /** @test */

--- a/tests/unit/RequestBuilder/SortingRequestBuilderTest.php
+++ b/tests/unit/RequestBuilder/SortingRequestBuilderTest.php
@@ -10,6 +10,7 @@ use Lmc\Matej\Model\Command\Sorting;
 use Lmc\Matej\Model\Command\UserMerge;
 use Lmc\Matej\Model\Request;
 use Lmc\Matej\Model\Response;
+use Lmc\Matej\Model\Response\SortingResponse;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -46,6 +47,7 @@ class SortingRequestBuilderTest extends TestCase
         $this->assertSame($sortingCommand, $requestData[2]);
 
         $this->assertSame('custom-request-id-foo', $request->getRequestId());
+        $this->assertSame(SortingResponse::class, $request->getResponseClass());
     }
 
     /** @test */


### PR DESCRIPTION
So now you can do this:

```php
$recommendations = $matej->request()
    ->recommendation(UserRecommendation::create('user-id', 5, 'test-scenario', 1.0, 3600))
    ->send()
    ->getRecommendation()
    ->getData();

$sortedItems =  $matej->request()
    ->sorting(Sorting::create('user-id', ['item-id-1', 'item-id-2', 'item-id-3']))
    ->send()
    ->getSorting()
    ->getData();

$properties = $matej->request()
    ->getItemProperties()
    ->send()
    ->getData();
```