### PR TITLE
Fix default filter in user recommendations

### DIFF
--- a/src/Model/Command/UserRecommendation.php
+++ b/src/Model/Command/UserRecommendation.php
@@ -30,7 +30,7 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
     /** @var string */
     private $minimalRelevance = self::MINIMAL_RELEVANCE_LOW;
     /** @var array */
-    private $filters = ['valid_to >= NOW'];
+    private $filters = ['NOW <= valid_to'];
 
     private function __construct(string $userId, int $count, string $scenario, float $rotationRate, int $rotationTime)
     {

--- a/tests/unit/Model/Command/UserRecommendationTest.php
+++ b/tests/unit/Model/Command/UserRecommendationTest.php
@@ -23,7 +23,7 @@ class UserRecommendationTest extends TestCase
                     'rotation_time' => 3600,
                     'hard_rotation' => false,
                     'min_relevance' => UserRecommendation::MINIMAL_RELEVANCE_LOW,
-                    'filter' => 'valid_to >= NOW',
+                    'filter' => 'NOW <= valid_to',
                 ],
             ],
             $command->jsonSerialize()
@@ -71,14 +71,14 @@ class UserRecommendationTest extends TestCase
         $command = UserRecommendation::create('user-id', 333, 'test-scenario', 1.0, 3600);
 
         // Default filter
-        $this->assertSame('valid_to >= NOW', $command->jsonSerialize()['parameters']['filter']);
+        $this->assertSame('NOW <= valid_to', $command->jsonSerialize()['parameters']['filter']);
 
         // Add custom filters to the default one
         $command->addFilter('foo = bar')
             ->addFilter('bar = baz');
 
         $this->assertSame(
-            'valid_to >= NOW and foo = bar and bar = baz',
+            'NOW <= valid_to and foo = bar and bar = baz',
             $command->jsonSerialize()['parameters']['filter']
         );
 


### PR DESCRIPTION
At this moment, filters are hardcoded. There is no `valid_to >= now` filter, we have `NOW <= valid_to`

This fixes the issue - the filter should work now.

Filter query language is being implemented under RAD-286, and should be available soon.