### PR TITLE
Fix checking of user ids when building requests for recommendation and sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Changed
 - Unify `self`/`static`/`$this` return typehints.
 
+### Fixed
+- Checking of consistent user ids on `recommendation()` and `sorting()` requests was not working in accordance with API behavior.
+
 ## 1.1.0 - 2017-12-20
 ### Added
 - Endpoint to get all defined item properties in the Matej database (`$matej->request()->getItemProperties()`).

--- a/src/Exception/LogicException.php
+++ b/src/Exception/LogicException.php
@@ -23,6 +23,17 @@ class LogicException extends \LogicException implements MatejExceptionInterface
         return new static($message);
     }
 
+    public static function forInconsistentUserMergeAndInteractionCommand($userMergeId, $interactionUserId)
+    {
+        $message = sprintf(
+            'Source user in UserMerge command ("%s") must be the same as user in Interaction command ("%s")',
+            $userMergeId,
+            $interactionUserId
+        );
+
+        return new self($message);
+    }
+
     public static function forClassNotExtendingOtherClass($class, $wantedClass)
     {
         return new self(sprintf('Class %s has to be instance or subclass of %s.', $class, $wantedClass));

--- a/src/Model/Command/UserMerge.php
+++ b/src/Model/Command/UserMerge.php
@@ -46,6 +46,11 @@ class UserMerge extends AbstractCommand implements UserAwareInterface
         return $this->targetUserId;
     }
 
+    public function getSourceUserId(): string
+    {
+        return $this->sourceUserId;
+    }
+
     protected function setSourceUserId(string $sourceUserId): void
     {
         Assertion::typeIdentifier($sourceUserId);

--- a/tests/integration/RequestBuilder/RecommendationRequestBuilderTest.php
+++ b/tests/integration/RequestBuilder/RecommendationRequestBuilderTest.php
@@ -20,7 +20,7 @@ class RecommendationRequestBuilderTest extends IntegrationTestCase
     {
         $response = $this->createMatejInstance()
             ->request()
-            ->recommendation($this->createRecommendationCommand())
+            ->recommendation($this->createRecommendationCommand('user-a'))
             ->send();
 
         $this->assertInstanceOf(RecommendationsResponse::class, $response);
@@ -33,8 +33,8 @@ class RecommendationRequestBuilderTest extends IntegrationTestCase
     {
         $response = $this->createMatejInstance()
             ->request()
-            ->recommendation($this->createRecommendationCommand())
-            ->setUserMerge(UserMerge::mergeInto('user-a', 'user-b'))
+            ->recommendation($this->createRecommendationCommand('user-b'))
+            ->setUserMerge(UserMerge::mergeInto('user-b', 'user-a'))
             ->setInteraction(Interaction::bookmark('user-a', 'item-a'))
             ->send();
 
@@ -43,10 +43,10 @@ class RecommendationRequestBuilderTest extends IntegrationTestCase
         $this->assertShorthandResponse($response, 'OK', 'OK', 'OK');
     }
 
-    private function createRecommendationCommand(): UserRecommendation
+    private function createRecommendationCommand(string $username): UserRecommendation
     {
         return UserRecommendation::create(
-            'user-a',
+            $username,
             5,
             'integration-test-scenario',
             0.50,

--- a/tests/integration/RequestBuilder/SortingRequestTest.php
+++ b/tests/integration/RequestBuilder/SortingRequestTest.php
@@ -33,8 +33,8 @@ class SortingRequestTest extends IntegrationTestCase
     {
         $response = $this->createMatejInstance()
             ->request()
-            ->sorting(Sorting::create('user-a', ['item-a', 'item-b', 'itemC-c']))
-            ->setUserMerge(UserMerge::mergeInto('user-a', 'user-b'))
+            ->sorting(Sorting::create('user-b', ['item-a', 'item-b', 'itemC-c']))
+            ->setUserMerge(UserMerge::mergeInto('user-b', 'user-a'))
             ->setInteraction(Interaction::bookmark('user-a', 'item-a'))
             ->send();
 

--- a/tests/unit/Model/Command/UserMergeTest.php
+++ b/tests/unit/Model/Command/UserMergeTest.php
@@ -37,5 +37,6 @@ class UserMergeTest extends UnitTestCase
             $command->jsonSerialize()
         );
         $this->assertSame($targetUserId, $command->getUserId());
+        $this->assertSame($sourceUserId, $command->getSourceUserId());
     }
 }

--- a/tests/unit/RequestBuilder/RecommendationRequestBuilderTest.php
+++ b/tests/unit/RequestBuilder/RecommendationRequestBuilderTest.php
@@ -26,7 +26,7 @@ class RecommendationRequestBuilderTest extends TestCase
         $recommendationsCommand = UserRecommendation::create('userId1', 5, 'test-scenario', 0.5, 3600);
         $builder = new RecommendationRequestBuilder($recommendationsCommand);
 
-        $interactionCommand = Interaction::detailView('userId1', 'itemId1');
+        $interactionCommand = Interaction::detailView('sourceId1', 'itemId1');
         $builder->setInteraction($interactionCommand);
 
         $userMergeCommand = UserMerge::mergeFromSourceToTargetUser('sourceId1', 'userId1');
@@ -76,7 +76,7 @@ class RecommendationRequestBuilderTest extends TestCase
     }
 
     /** @test */
-    public function shouldThrowExceptionWhenUserOfInteractionDiffersFromSorting(): void
+    public function shouldThrowExceptionWhenInteractionIsForUnrelatedUser(): void
     {
         $builder = new RecommendationRequestBuilder(
             $recommendationsCommand = UserRecommendation::create('userId1', 5, 'scenario', 0.5, 3600)
@@ -93,7 +93,7 @@ class RecommendationRequestBuilderTest extends TestCase
     }
 
     /** @test */
-    public function shouldThrowExceptionWhenUserOfUserMergeDiffersFromSorting(): void
+    public function shouldThrowExceptionWhenMergeIsForUnrelatedUser(): void
     {
         $builder = new RecommendationRequestBuilder(
             $recommendationsCommand = UserRecommendation::create('userId1', 5, 'scenario', 0.5, 3600)
@@ -106,6 +106,43 @@ class RecommendationRequestBuilderTest extends TestCase
             'User in UserMerge command ("different-user") must be the same as user in UserRecommendation command'
             . ' ("userId1")'
         );
+        $builder->build();
+    }
+
+    /**
+     * ([interaction], [user merge], [recommendation]): (A, A -> B, B)
+     * @test
+     */
+    public function shouldPassOnCorrectSequenceOfUsersWhenMerging(): void
+    {
+        $interactionCommand = Interaction::purchase('test-user-a', 'test-item-id');
+        $userMergeCommand = UserMerge::mergeFromSourceToTargetUser('test-user-a', 'test-user-b');
+        $recommendationsCommand = UserRecommendation::create('test-user-b', 5, 'scenario', 0.5, 3600);
+
+        $builder = new RecommendationRequestBuilder($recommendationsCommand);
+        $builder->setUserMerge($userMergeCommand);
+        $builder->setInteraction($interactionCommand);
+        $this->assertInstanceOf(Request::class, $builder->build());
+    }
+
+    /**
+     * ([interaction], [user merge], [recommendation]): (A, B -> A, A)
+     * @test
+     */
+    public function shouldFailOnIncorrectSequenceOfUsersWhenMerging(): void
+    {
+        $interactionCommand = Interaction::purchase('test-user-a', 'test-item-id');
+        $userMergeCommand = UserMerge::mergeFromSourceToTargetUser('test-user-b', 'test-user-a');
+        $recommendationsCommand = UserRecommendation::create('test-user-a', 5, 'scenario', 0.5, 3600);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            'Source user in UserMerge command ("test-user-b") must be the same as user in Interaction command ("test-user-a")'
+        );
+
+        $builder = new RecommendationRequestBuilder($recommendationsCommand);
+        $builder->setUserMerge($userMergeCommand);
+        $builder->setInteraction($interactionCommand);
         $builder->build();
     }
 }


### PR DESCRIPTION
Sorting and Recommendation endpoints allow optional Interaction and User Merge. These are currently checked, so that they contain the recommendation/sorting user id.

When user merge is present, the `interaction` has to cointain **old user id**, not the new one.

```
Consider /recommendation or /sorting request:
([interaction], [user merge], recommendation|sorting)

These requests are valid:
(A, null, A)
(A, A -> B, B)
(null, A -> B, B)

These requests are invalid and should be rejected:
( A  ,  null , B)
( A  , B -> A, A)
( B  , B -> A, B)
``` 

Currently, Matej's API will accept valid requests, and reject the wrong ones.

Current PHP Client behaviour:
```
(A, A -> B, B) - throws exception (interaction differs from master user)
(A, B -> A, A) - passes validation, but Matej's API will reject this
```

This PR remedies the issue.
  