### PR TITLE
Add exception when merging same user ids (RAD-907)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+### Fixed
+- Check for equality of user ids in `UserMerge` - so that we don't "merge" user into the same user id
 
 ## 1.3.0 - 2018-01-19
 ### Changed

--- a/src/Model/Command/UserMerge.php
+++ b/src/Model/Command/UserMerge.php
@@ -19,6 +19,8 @@ class UserMerge extends AbstractCommand implements UserAwareInterface
     {
         $this->setTargetUserId($targetUserId);
         $this->setSourceUserId($sourceUserId);
+
+        $this->assertUserIdsNotEqual();
     }
 
     /**
@@ -63,6 +65,15 @@ class UserMerge extends AbstractCommand implements UserAwareInterface
         Assertion::typeIdentifier($targetUserId);
 
         $this->targetUserId = $targetUserId;
+    }
+
+    private function assertUserIdsNotEqual(): void
+    {
+        Assertion::notEq(
+            $this->sourceUserId,
+            $this->targetUserId,
+            'You have to provide different source and target user id in UserMerge ("%s" set for both)'
+        );
     }
 
     protected function getCommandType(): string

--- a/tests/unit/Model/Command/UserMergeTest.php
+++ b/tests/unit/Model/Command/UserMergeTest.php
@@ -2,6 +2,7 @@
 
 namespace Lmc\Matej\Model\Command;
 
+use Assert\InvalidArgumentException;
 use Lmc\Matej\UnitTestCase;
 
 class UserMergeTest extends UnitTestCase
@@ -17,6 +18,14 @@ class UserMergeTest extends UnitTestCase
 
         $command = UserMerge::mergeFromSourceToTargetUser($sourceUserId, $targetUserId);
         $this->assertUserMergeCommand($command, $sourceUserId, $targetUserId);
+    }
+
+    public function shouldThrowExceptionWhenMergingSameUsers(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('You have to provide different source and target user id in UserMerge ("test-user" set for both)');
+
+        UserMerge::mergeInto('test-user', 'test-user');
     }
 
     /**


### PR DESCRIPTION
In near future, Matej API will stop accepting UserMerge requests, that cotain same user ids.