### PR TITLE
Explain why installing guzzlehttp/psr7 may be needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ If you, for example, want to use Guzzle 6 as the underlying HTTP library, instal
 $ composer require lmc/matej-client php-http/guzzle6-adapter # use lmc/matej-client-php5 instead for PHP 5.6 version
 ```
 
+Or if you want to use Guzzle 5 (note that unlike `guzzle6-adapter`, the one does not come with `guzzlehttp/psr7`, so you must install it as well):
+
+```sh
+$ composer require lmc/matej-client php-http/guzzle5-adapter guzzlehttp/psr7 # use lmc/matej-client-php5 instead for PHP 5.6 version
+```
+
 Or if you want to use cURL client:
 
 ```sh


### PR DESCRIPTION
Unlike guzzle6-adapter, the php-http/guzzle5-adapter does not contain PSR 7 interfaces, so `guzzlehttp/psr7` must be installed as well.

```
[Symfony\Component\Debug\Exception\ClassNotFoundException]                                                                                                                        
 Attempted to load class "Request" from namespace "GuzzleHttp\Psr7".                                                       
                                                       
 Did you forget a "use" statement for e.g. "Unirest\Request", "Solarium\Core\Client\Request", "Buzz\Message\Request", "Symfony\Component\BrowserKit\Request", "Symfony\Component\  
```

It may be convenient if this is mentioned in the README so users are not surprised.