### PR TITLE
Implement AB testing for Matej recommendation models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+### Added
+- A/B testing support for recommendation and sorting requests.
 
 ## 1.4.0 - 2018-02-23
 ### Added

--- a/README.md
+++ b/README.md
@@ -251,6 +251,51 @@ $response = $matej->request()
     ->send();
 ```
 
+### A/B Testing support
+`Recommendation` and `Sorting` commands now support optional A/B testing of various models. This has to be set up in Matej first,
+but once available, you can specify which model you want to use when requesting recommendations:
+
+```php
+$response = $matej->request()
+    ->recommendation(UserRecommendation::create('user-id', 5, 'test-scenario', 1.0, 3600, 'custom_name_of_model_b'))
+    ->send();
+```
+
+Or, you can use `setModelName` setter, if you're specifying parameters granularly:
+
+```php
+$recommendation = UserRecommendation::create('user-id', 5, 'test-scenario', 1.0, 3600);
+$recommendation->setModelName('custom_name_of_model_b');
+
+$response = $matej->request()
+    ->recommendation($recommendation)
+    ->send();
+```
+
+Similarly, you can do that for `Sorting` request:
+
+```php
+$response =  $matej->request()
+    ->sorting(Sorting::create('user-id', ['item-id-1', 'item-id-2', 'item-id-3'], 'custom_name_of_model_b'))
+    ->send()
+;
+
+// ... or ...
+$sorting = Sorting::create('user-id', ['item-id-1', 'item-id-2', 'item-id-3']);
+$sorting->setModelName('custom_name_of_model_b');
+
+$response = $matej->request()
+    ->sorting($sorting)
+    ->send();
+```
+
+`custom_name_of_model_b` will be provided to you by LMC.
+
+If you use `NULL`, or `'default'`, the default model for your instance will be used.
+
+A/B testing is available in `/recommendation` and `/sorting` endpoints for individual requests,
+as well as in `/campaign` endpoint for batch requests.
+
 ### Exceptions and error handling
 
 Exceptions are thrown only if the whole Request to Matej failed (when sending, decoding, authenticating etc.) or if

--- a/src/Model/Command/Sorting.php
+++ b/src/Model/Command/Sorting.php
@@ -14,11 +14,17 @@ class Sorting extends AbstractCommand implements UserAwareInterface
     private $userId;
     /** @var string[] */
     private $itemIds = [];
+    /** @var string|null */
+    private $modelName = null;
 
-    private function __construct(string $userId, array $itemIds)
+    private function __construct(string $userId, array $itemIds, string $modelName = null)
     {
         $this->setUserId($userId);
         $this->setItemIds($itemIds);
+
+        if ($modelName !== null) {
+            $this->setModelName($modelName);
+        }
     }
 
     /**
@@ -26,9 +32,23 @@ class Sorting extends AbstractCommand implements UserAwareInterface
      *
      * @return static
      */
-    public static function create(string $userId, array $itemIds): self
+    public static function create(string $userId, array $itemIds, string $modelName = null): self
     {
-        return new static($userId, $itemIds);
+        return new static($userId, $itemIds, $modelName);
+    }
+
+    /**
+     * Set A/B model name
+     *
+     * @return $this
+     */
+    public function setModelName(string $modelName): self
+    {
+        Assertion::typeIdentifier($modelName);
+
+        $this->modelName = $modelName;
+
+        return $this;
     }
 
     public function getUserId(): string
@@ -57,9 +77,15 @@ class Sorting extends AbstractCommand implements UserAwareInterface
 
     protected function getCommandParameters(): array
     {
-        return [
+        $parameters = [
             'user_id' => $this->userId,
             'item_ids' => $this->itemIds,
         ];
+
+        if ($this->modelName !== null) {
+            $parameters['model_name'] = $this->modelName;
+        }
+
+        return $parameters;
     }
 }

--- a/src/Model/Command/Sorting.php
+++ b/src/Model/Command/Sorting.php
@@ -17,14 +17,11 @@ class Sorting extends AbstractCommand implements UserAwareInterface
     /** @var string|null */
     private $modelName = null;
 
-    private function __construct(string $userId, array $itemIds, string $modelName = null)
+    private function __construct(string $userId, array $itemIds, ?string $modelName = null)
     {
         $this->setUserId($userId);
         $this->setItemIds($itemIds);
-
-        if ($modelName !== null) {
-            $this->setModelName($modelName);
-        }
+        $this->setModelName($modelName);
     }
 
     /**
@@ -42,9 +39,11 @@ class Sorting extends AbstractCommand implements UserAwareInterface
      *
      * @return $this
      */
-    public function setModelName(string $modelName): self
+    public function setModelName(?string $modelName): self
     {
-        Assertion::typeIdentifier($modelName);
+        if ($modelName !== null) {
+            Assertion::typeIdentifier($modelName);
+        }
 
         $this->modelName = $modelName;
 

--- a/src/Model/Command/UserRecommendation.php
+++ b/src/Model/Command/UserRecommendation.php
@@ -34,17 +34,14 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
     /** @var string|null */
     private $modelName = null;
 
-    private function __construct(string $userId, int $count, string $scenario, float $rotationRate, int $rotationTime, string $modelName = null)
+    private function __construct(string $userId, int $count, string $scenario, float $rotationRate, int $rotationTime, ?string $modelName = null)
     {
         $this->setUserId($userId);
         $this->setCount($count);
         $this->setScenario($scenario);
         $this->setRotationRate($rotationRate);
         $this->setRotationTime($rotationTime);
-
-        if ($modelName !== null) {
-            $this->setModelName($modelName);
-        }
+        $this->setModelName($modelName);
     }
 
     /**
@@ -134,9 +131,11 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
      *
      * @return $this
      */
-    public function setModelName(string $modelName): self
+    public function setModelName(?string $modelName): self
     {
-        Assertion::typeIdentifier($modelName);
+        if ($modelName !== null) {
+            Assertion::typeIdentifier($modelName);
+        }
 
         $this->modelName = $modelName;
 

--- a/tests/integration/RequestBuilder/EventsRequestBuilderTest.php
+++ b/tests/integration/RequestBuilder/EventsRequestBuilderTest.php
@@ -6,13 +6,37 @@ use Lmc\Matej\Exception\LogicException;
 use Lmc\Matej\IntegrationTests\IntegrationTestCase;
 use Lmc\Matej\Model\Command\Interaction;
 use Lmc\Matej\Model\Command\ItemProperty;
+use Lmc\Matej\Model\Command\ItemPropertySetup;
 use Lmc\Matej\Model\Command\UserMerge;
+use Lmc\Matej\RequestBuilder\ItemPropertiesSetupRequestBuilder;
 
 /**
  * @covers \Lmc\Matej\RequestBuilder\EventsRequestBuilder
  */
 class EventsRequestBuilderTest extends IntegrationTestCase
 {
+    private function buildAndSendPropertySetupRequest(ItemPropertiesSetupRequestBuilder $builder): void
+    {
+        $builder->addProperty(ItemPropertySetup::string('test_property_a'))
+            ->addProperty(ItemPropertySetup::string('test_property_b'))
+            ->addProperty(ItemPropertySetup::string('test_property_c'))
+            ->send();
+    }
+
+    protected function setup(): void
+    {
+        $builder = $this->createMatejInstance()->request()->setupItemProperties();
+
+        $this->buildAndSendPropertySetupRequest($builder);
+    }
+
+    protected function tearDown(): void
+    {
+        $builder = $this->createMatejInstance()->request()->deleteItemProperties();
+
+        $this->buildAndSendPropertySetupRequest($builder);
+    }
+
     /** @test */
     public function shouldThrowExceptionWhenSendingBlankRequest(): void
     {

--- a/tests/integration/RequestBuilder/SortingRequestTest.php
+++ b/tests/integration/RequestBuilder/SortingRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Lmc\Matej\IntegrationTests\RequestBuilder;
 
+use Lmc\Matej\Exception\RequestException;
 use Lmc\Matej\IntegrationTests\IntegrationTestCase;
 use Lmc\Matej\Model\Command\Interaction;
 use Lmc\Matej\Model\Command\Sorting;
@@ -33,7 +34,7 @@ class SortingRequestTest extends IntegrationTestCase
     {
         $response = $this->createMatejInstance()
             ->request()
-            ->sorting(Sorting::create('user-b', ['item-a', 'item-b', 'itemC-c']))
+            ->sorting(Sorting::create('user-b', ['item-a', 'item-b', 'itemC-c'], 'default'))
             ->setUserMerge(UserMerge::mergeInto('user-b', 'user-a'))
             ->setInteraction(Interaction::bookmark('user-a', 'item-a'))
             ->send();
@@ -41,6 +42,19 @@ class SortingRequestTest extends IntegrationTestCase
         $this->assertInstanceOf(SortingResponse::class, $response);
         $this->assertResponseCommandStatuses($response, 'OK', 'OK', 'OK');
         $this->assertShorthandResponse($response, 'OK', 'OK', 'OK');
+    }
+
+    /** @test */
+    public function shouldFailOnInvalidModelName(): void
+    {
+        $this->expectException(RequestException::class);
+        $this->expectExceptionCode(400);
+        $this->expectExceptionMessage('BAD REQUEST');
+
+        $this->createMatejInstance()
+            ->request()
+            ->sorting(Sorting::create('user-b', ['item-a', 'item-b', 'itemC-c'], 'invalid-model-name'))
+            ->send();
     }
 
     private function assertShorthandResponse(SortingResponse $response, $interactionStatus, $userMergeStatus, $sortingStatus): void

--- a/tests/unit/Model/Command/SortingTest.php
+++ b/tests/unit/Model/Command/SortingTest.php
@@ -11,9 +11,13 @@ class SortingTest extends UnitTestCase
     {
         $userId = 'user-id';
         $itemIds = ['item-1', 'item-3', 'item-2'];
+        $modelName = 'test-model-name';
 
         $command = Sorting::create($userId, $itemIds);
         $this->assertSortingCommand($command, $userId, $itemIds);
+
+        $command = Sorting::create($userId, $itemIds, $modelName);
+        $this->assertSortingCommand($command, $userId, $itemIds, $modelName);
     }
 
     /**
@@ -21,16 +25,22 @@ class SortingTest extends UnitTestCase
      *
      * @param Sorting $command
      */
-    private function assertSortingCommand($command, string $userId, array $itemIds): void
+    private function assertSortingCommand($command, string $userId, array $itemIds, ?string $modelName = null): void
     {
+        $parameters = [
+            'user_id' => $userId,
+            'item_ids' => $itemIds,
+        ];
+
+        if ($modelName !== null) {
+            $parameters['model_name'] = $modelName;
+        }
+
         $this->assertInstanceOf(Sorting::class, $command);
         $this->assertSame(
             [
                 'type' => 'sorting',
-                'parameters' => [
-                    'user_id' => $userId,
-                    'item_ids' => $itemIds,
-                ],
+                'parameters' => $parameters,
             ],
             $command->jsonSerialize()
         );

--- a/tests/unit/Model/Command/UserRecommendationTest.php
+++ b/tests/unit/Model/Command/UserRecommendationTest.php
@@ -24,6 +24,7 @@ class UserRecommendationTest extends TestCase
                     'hard_rotation' => false,
                     'min_relevance' => UserRecommendation::MINIMAL_RELEVANCE_LOW,
                     'filter' => 'valid_to >= NOW',
+                    // intentionally no model name ==> should be absent when not used
                 ],
             ],
             $command->jsonSerialize()
@@ -39,8 +40,9 @@ class UserRecommendationTest extends TestCase
         $scenario = 'scenario-' . md5(microtime());
         $rotationRate = mt_rand() / mt_getrandmax();
         $rotationTime = random_int(1, 86400);
+        $modelName = 'test-model-' . md5(microtime());
 
-        $command = UserRecommendation::create($userId, $count, $scenario, $rotationRate, $rotationTime);
+        $command = UserRecommendation::create($userId, $count, $scenario, $rotationRate, $rotationTime, $modelName);
 
         $command->setMinimalRelevance(UserRecommendation::MINIMAL_RELEVANCE_HIGH)
             ->enableHardRotation()
@@ -59,6 +61,7 @@ class UserRecommendationTest extends TestCase
                     'hard_rotation' => true,
                     'min_relevance' => UserRecommendation::MINIMAL_RELEVANCE_HIGH,
                     'filter' => 'foo = bar and baz = ban',
+                    'model_name' => $modelName,
                 ],
             ],
             $command->jsonSerialize()

--- a/tests/unit/RequestBuilder/RecommendationRequestBuilderTest.php
+++ b/tests/unit/RequestBuilder/RecommendationRequestBuilderTest.php
@@ -23,7 +23,7 @@ class RecommendationRequestBuilderTest extends TestCase
     /** @test */
     public function shouldBuildRequestWithCommands(): void
     {
-        $recommendationsCommand = UserRecommendation::create('userId1', 5, 'test-scenario', 0.5, 3600);
+        $recommendationsCommand = UserRecommendation::create('userId1', 5, 'test-scenario', 0.5, 3600, 'test_model');
         $builder = new RecommendationRequestBuilder($recommendationsCommand);
 
         $interactionCommand = Interaction::detailView('sourceId1', 'itemId1');

--- a/tests/unit/RequestBuilder/SortingRequestBuilderTest.php
+++ b/tests/unit/RequestBuilder/SortingRequestBuilderTest.php
@@ -23,7 +23,7 @@ class SortingRequestBuilderTest extends TestCase
     /** @test */
     public function shouldBuildRequestWithCommands(): void
     {
-        $sortingCommand = Sorting::create('userId1', ['itemId1', 'itemId2']);
+        $sortingCommand = Sorting::create('userId1', ['itemId1', 'itemId2'], 'test_model_name');
         $builder = new SortingRequestBuilder($sortingCommand);
 
         $interactionCommand = Interaction::detailView('sourceId1', 'itemId1');


### PR DESCRIPTION
|  |  |
| --- | --- |
| **Type** | Feature |
| **Fixes issues** | RAD-1066 |
| **Documentation** | updated |
| **BC Break** | no |
| **Tests updated** | yes |

Contains implementation for A/B testing of various recommendation models. These models have to be implemented/deployed in Matej first, before they're available for any given client. This is by design, as new model requires full recalculation, and therefore availability is individual depending on the size of clients data.

By default, only `default` model is available for every client (which means *clients* default, not *matej* default.)

Requires **Matej release ~v7.37~ v7.36**
Currently deployed to Staging instance, which contains models `default` and `model_b`.

There is no API endpoint that'd list available models. No validation beyond basic identifier is required.