### PR TITLE
count should assert when calling setCount with non integer parameter

### DIFF
--- a/src/Model/Command/UserRecommendation.php
+++ b/src/Model/Command/UserRecommendation.php
@@ -135,6 +135,7 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
 
     protected function setCount(int $count): void
     {
+        Assertion::integer($count); // for PHP5 clients
         Assertion::greaterThan($count, 0);
 
         $this->count = $count;


### PR DESCRIPTION
for PHP5 version where type don't force integer value