### PR TITLE
Fix failing intergration test (RAD-1066)

### DIFF
--- a/tests/integration/IntegrationTestCase.php
+++ b/tests/integration/IntegrationTestCase.php
@@ -8,20 +8,20 @@ use PHPUnit\Framework\TestCase;
 
 class IntegrationTestCase extends TestCase
 {
-    protected function markAsSkippedIfMatejIsNotAvailable(): void
+    protected static function markAsSkippedIfMatejIsNotAvailable(): void
     {
         if (!getenv('MATEJ_TEST_ACCOUNTID')) {
-            $this->markTestSkipped('Environment variable MATEJ_TEST_ACCOUNTID has to be defined');
+            self::markTestSkipped('Environment variable MATEJ_TEST_ACCOUNTID has to be defined');
         }
 
         if (!getenv('MATEJ_TEST_APIKEY')) {
-            $this->markTestSkipped('Environment variable MATEJ_TEST_APIKEY has to be defined');
+            self::markTestSkipped('Environment variable MATEJ_TEST_APIKEY has to be defined');
         }
     }
 
-    protected function createMatejInstance(): Matej
+    protected static function createMatejInstance(): Matej
     {
-        $this->markAsSkippedIfMatejIsNotAvailable();
+        self::markAsSkippedIfMatejIsNotAvailable();
 
         $instance = new Matej(getenv('MATEJ_TEST_ACCOUNTID'), getenv('MATEJ_TEST_APIKEY'));
 
@@ -46,7 +46,7 @@ class IntegrationTestCase extends TestCase
     }
 
     /** @return string[] */
-    protected function generateOkStatuses(int $amount): array
+    protected static function generateOkStatuses(int $amount): array
     {
         $data = explode(',', str_repeat('OK,', $amount));
         array_pop($data);

--- a/tests/integration/MatejTest.php
+++ b/tests/integration/MatejTest.php
@@ -11,7 +11,7 @@ class MatejTest extends IntegrationTestCase
     {
         $requestId = uniqid('integration-test-php-client-request-id');
 
-        $response = $this->createMatejInstance()
+        $response = static::createMatejInstance()
             ->request()
             ->sorting(Sorting::create('integration-test-php-client-user-id-A', ['itemA', 'itemB']))
             ->setRequestId($requestId)

--- a/tests/integration/RequestBuilder/CampaignRequestBuilderTest.php
+++ b/tests/integration/RequestBuilder/CampaignRequestBuilderTest.php
@@ -18,7 +18,7 @@ class CampaignRequestBuilderTest extends IntegrationTestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('At least one command must be added to the builder before sending the request');
 
-        $this->createMatejInstance()
+        static::createMatejInstance()
             ->request()
             ->campaign()
             ->send();
@@ -27,7 +27,7 @@ class CampaignRequestBuilderTest extends IntegrationTestCase
     /** @test */
     public function shouldExecuteRecommendationAndSortingCommands(): void
     {
-        $response = $this->createMatejInstance()
+        $response = static::createMatejInstance()
             ->request()
             ->campaign()
             ->addRecommendation($this->createRecommendationCommand('a'))

--- a/tests/integration/RequestBuilder/EventsRequestBuilderTest.php
+++ b/tests/integration/RequestBuilder/EventsRequestBuilderTest.php
@@ -6,20 +6,40 @@ use Lmc\Matej\Exception\LogicException;
 use Lmc\Matej\IntegrationTests\IntegrationTestCase;
 use Lmc\Matej\Model\Command\Interaction;
 use Lmc\Matej\Model\Command\ItemProperty;
+use Lmc\Matej\Model\Command\ItemPropertySetup;
 use Lmc\Matej\Model\Command\UserMerge;
+use Lmc\Matej\RequestBuilder\ItemPropertiesSetupRequestBuilder;
 
 /**
  * @covers \Lmc\Matej\RequestBuilder\EventsRequestBuilder
  */
 class EventsRequestBuilderTest extends IntegrationTestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        $request = self::createMatejInstance()->request()->setupItemProperties();
+
+        self::addPropertiesToPropertySetupRequest($request);
+
+        $request->send();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        $request = self::createMatejInstance()->request()->deleteItemProperties();
+
+        self::addPropertiesToPropertySetupRequest($request);
+
+        $request->send();
+    }
+
     /** @test */
     public function shouldThrowExceptionWhenSendingBlankRequest(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('At least one command must be added to the builder before sending the request');
 
-        $this->createMatejInstance()
+        static::createMatejInstance()
             ->request()
             ->events()
             ->send();
@@ -28,7 +48,7 @@ class EventsRequestBuilderTest extends IntegrationTestCase
     /** @test */
     public function shouldExecuteInteractionAndUserMergeAndItemPropertyCommands(): void
     {
-        $response = $this->createMatejInstance()
+        $response = static::createMatejInstance()
             ->request()
             ->events()
             ->addInteraction(Interaction::bookmark('user-a', 'item-a'))
@@ -50,5 +70,14 @@ class EventsRequestBuilderTest extends IntegrationTestCase
             ->send();
 
         $this->assertResponseCommandStatuses($response, ...$this->generateOkStatuses(10));
+    }
+
+    private static function addPropertiesToPropertySetupRequest(ItemPropertiesSetupRequestBuilder $builder): void
+    {
+        $builder->addProperties([
+            ItemPropertySetup::string('test_property_a'),
+            ItemPropertySetup::string('test_property_b'),
+            ItemPropertySetup::string('test_property_c'),
+        ]);
     }
 }

--- a/tests/integration/RequestBuilder/ItemPropertiesGetRequestBuilderTest.php
+++ b/tests/integration/RequestBuilder/ItemPropertiesGetRequestBuilderTest.php
@@ -14,7 +14,7 @@ class ItemPropertiesGetRequestBuilderTest extends IntegrationTestCase
     /** @test */
     public function shouldGetListOfPropertiesFromMatej(): void
     {
-        $response = $this->createMatejInstance()
+        $response = static::createMatejInstance()
             ->request()
             ->getItemProperties()
             ->send();

--- a/tests/integration/RequestBuilder/ItemPropertiesSetupRequestBuilderTest.php
+++ b/tests/integration/RequestBuilder/ItemPropertiesSetupRequestBuilderTest.php
@@ -26,15 +26,15 @@ class ItemPropertiesSetupRequestBuilderTest extends IntegrationTestCase
     public function provideBuilders(): array
     {
         return [
-            'setup properties' => [$this->createMatejInstance()->request()->setupItemProperties()],
-            'delete properties' => [$this->createMatejInstance()->request()->deleteItemProperties()],
+            'setup properties' => [static::createMatejInstance()->request()->setupItemProperties()],
+            'delete properties' => [static::createMatejInstance()->request()->deleteItemProperties()],
         ];
     }
 
     /** @test */
     public function shouldCreateNewPropertiesInMatej(): void
     {
-        $response = $this->createMatejInstance()
+        $response = static::createMatejInstance()
             ->request()
             ->setupItemProperties()
             ->addProperty(Command\ItemPropertySetup::boolean('test_property_bool'))
@@ -59,7 +59,7 @@ class ItemPropertiesSetupRequestBuilderTest extends IntegrationTestCase
      */
     public function shouldDeleteCreatedPropertiesFromMatej(): void
     {
-        $response = $this->createMatejInstance()
+        $response = static::createMatejInstance()
             ->request()
             ->deleteItemProperties()
             ->addProperty(Command\ItemPropertySetup::boolean('test_property_bool'))

--- a/tests/integration/RequestBuilder/RecommendationRequestBuilderTest.php
+++ b/tests/integration/RequestBuilder/RecommendationRequestBuilderTest.php
@@ -18,7 +18,7 @@ class RecommendationRequestBuilderTest extends IntegrationTestCase
     /** @test */
     public function shouldExecuteRecommendationRequestOnly(): void
     {
-        $response = $this->createMatejInstance()
+        $response = static::createMatejInstance()
             ->request()
             ->recommendation($this->createRecommendationCommand('user-a'))
             ->send();
@@ -31,7 +31,7 @@ class RecommendationRequestBuilderTest extends IntegrationTestCase
     /** @test */
     public function shouldExecuteRecommendationRequestWithUserMergeAndInteraction(): void
     {
-        $response = $this->createMatejInstance()
+        $response = static::createMatejInstance()
             ->request()
             ->recommendation($this->createRecommendationCommand('user-b'))
             ->setUserMerge(UserMerge::mergeInto('user-b', 'user-a'))

--- a/tests/integration/RequestBuilder/ResetDatabaseRequestBuilderTest.php
+++ b/tests/integration/RequestBuilder/ResetDatabaseRequestBuilderTest.php
@@ -14,7 +14,7 @@ class ResetDatabaseRequestBuilderTest extends IntegrationTestCase
     /** @test */
     public function shouldResetMatejDatabase(): void
     {
-        $response = $this->createMatejInstance()
+        $response = static::createMatejInstance()
             ->request()
             ->resetDatabase()
             ->send();

--- a/tests/integration/RequestBuilder/SortingRequestTest.php
+++ b/tests/integration/RequestBuilder/SortingRequestTest.php
@@ -18,7 +18,7 @@ class SortingRequestTest extends IntegrationTestCase
     /** @test */
     public function shouldExecuteSortingRequestOnly(): void
     {
-        $response = $this->createMatejInstance()
+        $response = static::createMatejInstance()
             ->request()
             ->sorting(Sorting::create('user-a', ['itemA', 'itemB', 'itemC']))
             ->send();
@@ -31,7 +31,7 @@ class SortingRequestTest extends IntegrationTestCase
     /** @test */
     public function shouldExecuteSortingRequestWithUserMergeAndInteraction(): void
     {
-        $response = $this->createMatejInstance()
+        $response = static::createMatejInstance()
             ->request()
             ->sorting(Sorting::create('user-b', ['item-a', 'item-b', 'itemC-c']))
             ->setUserMerge(UserMerge::mergeInto('user-b', 'user-a'))


### PR DESCRIPTION
|  |  |
| --- | --- |
| **Type** | Bugfix |
| **Fixes issues** | n/a |
| **Documentation** | n/a |
| **BC Break** | no |
| **Tests updated** | yes |

Fixes failing integration test, which was failing because of uninitialized item properties.