### PR TITLE
Implement A/B testing support for Recommendations and Sorting commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Unreleased
 ### Added
+- A/B testing support for recommendation and sorting requests.
 - Type hints and type assertions relevant only for PHP 5 version removed from codebase and are now added only to PHP 5 version of the library (in `RequestBuilderFactory`, `Command\Interaction`, `Command\UserRecommendation`).
 
 ## 1.4.0 - 2018-02-23

--- a/src/Model/Command/Sorting.php
+++ b/src/Model/Command/Sorting.php
@@ -14,6 +14,8 @@ class Sorting extends AbstractCommand implements UserAwareInterface
     private $userId;
     /** @var string[] */
     private $itemIds = [];
+    /** @var string|null */
+    private $modelName = null;
 
     private function __construct(string $userId, array $itemIds)
     {
@@ -29,6 +31,20 @@ class Sorting extends AbstractCommand implements UserAwareInterface
     public static function create(string $userId, array $itemIds): self
     {
         return new static($userId, $itemIds);
+    }
+
+    /**
+     * Set A/B model name
+     *
+     * @return $this
+     */
+    public function setModelName(string $modelName): self
+    {
+        Assertion::typeIdentifier($modelName);
+
+        $this->modelName = $modelName;
+
+        return $this;
     }
 
     public function getUserId(): string
@@ -57,9 +73,15 @@ class Sorting extends AbstractCommand implements UserAwareInterface
 
     protected function getCommandParameters(): array
     {
-        return [
+        $parameters = [
             'user_id' => $this->userId,
             'item_ids' => $this->itemIds,
         ];
+
+        if ($this->modelName !== null) {
+            $parameters['model_name'] = $this->modelName;
+        }
+
+        return $parameters;
     }
 }

--- a/src/Model/Command/UserRecommendation.php
+++ b/src/Model/Command/UserRecommendation.php
@@ -31,6 +31,8 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
     private $minimalRelevance = self::MINIMAL_RELEVANCE_LOW;
     /** @var array */
     private $filters = ['valid_to >= NOW'];
+    /** @var string|null */
+    private $modelName = null;
 
     private function __construct(string $userId, int $count, string $scenario, float $rotationRate, int $rotationTime)
     {
@@ -121,6 +123,20 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
         return $this;
     }
 
+    /***
+     * Set A/B model name
+     *
+     * @return $this
+     */
+    public function setModelName(string $modelName): self
+    {
+        Assertion::typeIdentifier($modelName);
+
+        $this->modelName = $modelName;
+
+        return $this;
+    }
+
     public function getUserId(): string
     {
         return $this->userId;
@@ -173,7 +189,7 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
 
     protected function getCommandParameters(): array
     {
-        return [
+        $parameters = [
             'user_id' => $this->userId,
             'count' => $this->count,
             'scenario' => $this->scenario,
@@ -183,5 +199,11 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
             'min_relevance' => $this->minimalRelevance,
             'filter' => $this->assembleFiltersString(),
         ];
+
+        if ($this->modelName !== null) {
+            $parameters['model_name'] = $this->modelName;
+        }
+
+        return $parameters;
     }
 }

--- a/tests/integration/RequestBuilder/RecommendationRequestBuilderTest.php
+++ b/tests/integration/RequestBuilder/RecommendationRequestBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace Lmc\Matej\IntegrationTests\RequestBuilder;
 
+use Lmc\Matej\Exception\RequestException;
 use Lmc\Matej\IntegrationTests\IntegrationTestCase;
 use Lmc\Matej\Model\Command\Interaction;
 use Lmc\Matej\Model\Command\UserMerge;
@@ -41,6 +42,19 @@ class RecommendationRequestBuilderTest extends IntegrationTestCase
         $this->assertInstanceOf(RecommendationsResponse::class, $response);
         $this->assertResponseCommandStatuses($response, 'OK', 'OK', 'OK');
         $this->assertShorthandResponse($response, 'OK', 'OK', 'OK');
+    }
+
+    /** @test */
+    public function shouldFailOnInvalidModelName(): void
+    {
+        $this->expectException(RequestException::class);
+        $this->expectExceptionCode(400);
+        $this->expectExceptionMessage('BAD REQUEST');
+
+        $this->createMatejInstance()
+            ->request()
+            ->recommendation($this->createRecommendationCommand('user-a')->setModelName('invalid-model-name'))
+            ->send();
     }
 
     private function createRecommendationCommand(string $username): UserRecommendation

--- a/tests/integration/RequestBuilder/SortingRequestTest.php
+++ b/tests/integration/RequestBuilder/SortingRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Lmc\Matej\IntegrationTests\RequestBuilder;
 
+use Lmc\Matej\Exception\RequestException;
 use Lmc\Matej\IntegrationTests\IntegrationTestCase;
 use Lmc\Matej\Model\Command\Interaction;
 use Lmc\Matej\Model\Command\Sorting;
@@ -41,6 +42,19 @@ class SortingRequestTest extends IntegrationTestCase
         $this->assertInstanceOf(SortingResponse::class, $response);
         $this->assertResponseCommandStatuses($response, 'OK', 'OK', 'OK');
         $this->assertShorthandResponse($response, 'OK', 'OK', 'OK');
+    }
+
+    /** @test */
+    public function shouldFailOnInvalidModelName(): void
+    {
+        $this->expectException(RequestException::class);
+        $this->expectExceptionCode(400);
+        $this->expectExceptionMessage('BAD REQUEST');
+
+        $this->createMatejInstance()
+            ->request()
+            ->sorting(Sorting::create('user-b', ['item-a', 'item-b', 'itemC-c'])->setModelName('invalid-model-name'))
+            ->send();
     }
 
     private function assertShorthandResponse(SortingResponse $response, $interactionStatus, $userMergeStatus, $sortingStatus): void

--- a/tests/unit/Model/Command/SortingTest.php
+++ b/tests/unit/Model/Command/SortingTest.php
@@ -11,9 +11,13 @@ class SortingTest extends UnitTestCase
     {
         $userId = 'user-id';
         $itemIds = ['item-1', 'item-3', 'item-2'];
+        $modelName = 'test-model-name';
 
         $command = Sorting::create($userId, $itemIds);
         $this->assertSortingCommand($command, $userId, $itemIds);
+
+        $command->setModelName($modelName);
+        $this->assertSortingCommand($command, $userId, $itemIds, $modelName);
     }
 
     /**
@@ -21,16 +25,22 @@ class SortingTest extends UnitTestCase
      *
      * @param Sorting $command
      */
-    private function assertSortingCommand($command, string $userId, array $itemIds): void
+    private function assertSortingCommand($command, string $userId, array $itemIds, ?string $modelName = null): void
     {
+        $parameters = [
+            'user_id' => $userId,
+            'item_ids' => $itemIds,
+        ];
+
+        if ($modelName !== null) {
+            $parameters['model_name'] = $modelName;
+        }
+
         $this->assertInstanceOf(Sorting::class, $command);
         $this->assertSame(
             [
                 'type' => 'sorting',
-                'parameters' => [
-                    'user_id' => $userId,
-                    'item_ids' => $itemIds,
-                ],
+                'parameters' => $parameters,
             ],
             $command->jsonSerialize()
         );

--- a/tests/unit/Model/Command/UserRecommendationTest.php
+++ b/tests/unit/Model/Command/UserRecommendationTest.php
@@ -24,6 +24,7 @@ class UserRecommendationTest extends TestCase
                     'hard_rotation' => false,
                     'min_relevance' => UserRecommendation::MINIMAL_RELEVANCE_LOW,
                     'filter' => 'valid_to >= NOW',
+                    // intentionally no model name ==> should be absent when not used
                 ],
             ],
             $command->jsonSerialize()
@@ -39,12 +40,14 @@ class UserRecommendationTest extends TestCase
         $scenario = 'scenario-' . md5(microtime());
         $rotationRate = mt_rand() / mt_getrandmax();
         $rotationTime = random_int(1, 86400);
+        $modelName = 'test-model-' . md5(microtime());
 
         $command = UserRecommendation::create($userId, $count, $scenario, $rotationRate, $rotationTime);
 
         $command->setMinimalRelevance(UserRecommendation::MINIMAL_RELEVANCE_HIGH)
             ->enableHardRotation()
-            ->setFilters(['foo = bar', 'baz = ban']);
+            ->setFilters(['foo = bar', 'baz = ban'])
+            ->setModelName($modelName);
 
         $this->assertInstanceOf(UserRecommendation::class, $command);
         $this->assertSame(
@@ -59,6 +62,7 @@ class UserRecommendationTest extends TestCase
                     'hard_rotation' => true,
                     'min_relevance' => UserRecommendation::MINIMAL_RELEVANCE_HIGH,
                     'filter' => 'foo = bar and baz = ban',
+                    'model_name' => $modelName,
                 ],
             ],
             $command->jsonSerialize()


### PR DESCRIPTION
|  |  |
| --- | --- |
| **Type** | Feature |
| **Fixes issues** | RAD-1066 |
| **Documentation** | updated |
| **BC Break** | no |
| **Tests updated** | yes |

Contains implementation for A/B testing of various recommendation models. These models have to be implemented/deployed in Matej first, before they're available for any given client. This is by design, as new model requires full recalculation, and therefore availability is individual depending on the size of clients data.

By default, only `default` model is available for every client (which means *clients* default, not *matej* default.)

Requires **Matej release v7.36**
Currently deployed to Staging instance, which contains models `default` and `model_b`.

There is no API endpoint that'd list available models. No validation beyond basic identifier is required.