### PR TITLE
Detect BC breaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 composer.phar
 /vendor/
 coverage-clover.xml
+bc-changes.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,12 @@ matrix:
     - php: 7.1
       env: CHECK_CODESTYLE=1
       before_install: phpenv config-rm xdebug.ini
-      before_script: yarn add danger
+      before_script:
+        - composer require --dev roave/backward-compatibility-check:^1.0
+        - yarn add danger
       script:
         - composer analyze
+        - vendor/bin/roave-backward-compatibility-check --format=markdown >bc-changes.md
         - yarn danger ci
       after_success: ~
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
   include:
     - php: 7.1
       env: dependencies="--prefer-lowest"
-    - php: 7.1
+    - php: 7.2
       env: CHECK_CODESTYLE=1
       before_install: phpenv config-rm xdebug.ini
       before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+### Changed
+- Declare missing direct dependencies (to `php-http/message`, `php-http/promise` and `psr/http-message`) in composer.json.
 
 ## 1.5.0 - 2018-04-17
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -31,14 +31,16 @@
         "php-http/client-implementation": "^1.0",
         "php-http/discovery": "^1.0",
         "php-http/httplug": "^1.1",
+        "php-http/message": "^1.6",
         "php-http/message-factory": "^1.0",
+        "php-http/promise": "^1.0",
+        "psr/http-message": "^1.0",
         "ramsey/uuid": "^3.7"
     },
     "require-dev": {
         "lmc/coding-standard": "^1.0",
         "php-coveralls/php-coveralls": "^2.0",
         "php-http/guzzle6-adapter": "^1.1",
-        "php-http/message": "^1.0",
         "php-http/mock-client": "^1.0",
         "php-mock/php-mock-phpunit": "^1.0 || ^2.0",
         "phpstan/phpstan-phpunit": "^0.9.0",

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const fs = require('fs');
+const exec = require('child_process').exec;
 const commits = danger.github.commits;
 const pr = danger.github.pr;
 
@@ -15,4 +17,18 @@ for (const commit of commits) {
 // Warn if PR is too big
 if (pr.additions > 500) {
     warn('This PR is way too big, consider splitting it up to smaller ones. Reviewers will be thankful 🙏.')
+}
+
+// Print detected BC breaks
+const bcChangesFile = 'bc-changes.md';
+if (fs.existsSync(bcChangesFile)) {
+    exec('grep "\\[BC\\]" ' + bcChangesFile, function (error, results) {
+        if (results.length > 0) {
+            fail('Backward incompatible changes detected');
+            markdown(`
+## Backward incompatible changes introduced by this PR
+${results.toString()}
+`);
+        }
+    });
 }


### PR DESCRIPTION
Via https://github.com/Roave/BackwardCompatibilityCheck .

Also fixed some missing dependencies (which must be properly defined to make BackwardCompatibilityCheck work properly).

Danger should report BC breaks to the PR.

