### PR TITLE
Fix incorrect exceptions behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+### Fixed
+- Exceptions occurring during async request now generate rejected promise (as they should) and are no longer thrown directly.
 
 ## 1.6.0 - 2018-06-01
 ### Added

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -2,6 +2,7 @@
 
 namespace Lmc\Matej\Exception;
 
+use Http\Client\Exception;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -9,7 +10,7 @@ use Psr\Http\Message\ResponseInterface;
  * Generic exception thrown when error occurs during request execution.
  * Some more specific child exception could be thrown instead.
  */
-class RequestException extends \RuntimeException implements MatejExceptionInterface
+class RequestException extends \RuntimeException implements MatejExceptionInterface, Exception
 {
     /** @var RequestInterface */
     private $request;

--- a/tests/unit/Http/Plugin/ExceptionPluginTest.php
+++ b/tests/unit/Http/Plugin/ExceptionPluginTest.php
@@ -6,6 +6,7 @@ use Fig\Http\Message\StatusCodeInterface;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Http\Client\Promise\HttpFulfilledPromise;
+use Http\Client\Promise\HttpRejectedPromise;
 use Lmc\Matej\Exception\AuthorizationException;
 use Lmc\Matej\Exception\RequestException;
 use PHPUnit\Framework\TestCase;
@@ -31,6 +32,7 @@ class ExceptionPluginTest extends TestCase
         $plugin = new ExceptionPlugin();
         $promise = $plugin->handleRequest($request, $next, function (): void {});
         $this->assertInstanceOf(HttpFulfilledPromise::class, $promise);
+        $this->assertSame($response, $promise->wait());
     }
 
     /**
@@ -61,8 +63,11 @@ class ExceptionPluginTest extends TestCase
 
         $plugin = new ExceptionPlugin();
 
+        $promise = $plugin->handleRequest($request, $next, function (): void {});
+        $this->assertInstanceOf(HttpRejectedPromise::class, $promise);
+
         $this->expectException($expectedExceptionClass);
-        $plugin->handleRequest($request, $next, function (): void {});
+        $this->assertSame($response, $promise->wait());
     }
 
     /**


### PR DESCRIPTION
This bug has no impact if client is used synchronously. (Which is what currently everyone do, as far as I know.)

But if someone would like to use it as async client (which is one of nice HTTPlug [features](http://docs.php-http.org/en/latest/httplug/introduction.html#client-interfaces)), instead of exception a RejectedPromise should be returned to allow async processing of occurring errors. This is done internally by `Http\Client\Promise`, but it depends on exceptions having `Http\Client\Exception` interface (which is the only one converted to `HttpRejectedPromise`).

This is [stated in the manual](http://docs.php-http.org/en/latest/httplug/exceptions.html), but we apparently missed it :speak_no_evil: :
>  Every exception thrown by a HTTP client must implement Http\Client\Exception.