### PR TITLE
Skip class suffix sniff for Matej Commands

### DIFF
--- a/easy-coding-standard.yaml
+++ b/easy-coding-standard.yaml
@@ -4,3 +4,7 @@ imports:
 services:
     PhpCsFixer\Fixer\PhpUnit\PhpUnitTestAnnotationFixer:
         style: annotation
+parameters:
+    skip:
+        Symplify\CodingStandard\Sniffs\Naming\ClassNameSuffixByParentSniff:
+            - 'src/Model/Command/*.php'


### PR DESCRIPTION
Now detected by ECS, but the postix is not used by Matej Commands (which are not descendants of  Symfony/Command, its a how "actions" are called in Matej domain). 

The change to add the postfix to the classes would be also BC, so IMO not worth the change.