### PR TITLE
Add MQL support for recommendations filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,16 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+### Changed
+- **BC BREAK** | `UserRecommendation` now returns new format of response in `->getData()`, which is a list of `stdClass` instances.
+- **BC BREAK** | `UserRecommendation` does not have default filter (was previously set to: `valid_to >= NOW`).
+
 ### Fixed
 - Exceptions occurring during async request now generate rejected promise (as they should) and are no longer thrown directly.
+
+### Added
+- `UserRecommendation` now sends which item properties should be returned alongside with item_ids.
+- **BC BREAK** | `UserRecommendation` now uses MQL query language by default for filtering.
 
 ## 1.6.0 - 2018-06-01
 ### Added

--- a/src/Model/Command/UserRecommendation.php
+++ b/src/Model/Command/UserRecommendation.php
@@ -12,6 +12,8 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
     public const MINIMAL_RELEVANCE_LOW = 'low';
     public const MINIMAL_RELEVANCE_MEDIUM = 'medium';
     public const MINIMAL_RELEVANCE_HIGH = 'high';
+    public const FILTER_TYPE_RGX = 'rgx';
+    public const FILTER_TYPE_MQL = 'mql';
 
     /** @var string */
     protected $filterOperator = 'and';
@@ -29,18 +31,29 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
     private $hardRotation = false;
     /** @var string */
     private $minimalRelevance = self::MINIMAL_RELEVANCE_LOW;
-    /** @var array */
-    private $filters = ['valid_to >= NOW'];
+    /** @var string[] */
+    private $filters = [];
+    /** @var bool */
+    private $filterType = self::FILTER_TYPE_MQL;
     /** @var string|null */
     private $modelName = null;
+    /** @var string[] */
+    private $responseProperties;
 
-    private function __construct(string $userId, int $count, string $scenario, float $rotationRate, int $rotationTime)
-    {
+    private function __construct(
+        string $userId,
+        int $count,
+        string $scenario,
+        float $rotationRate,
+        int $rotationTime,
+        array $responseProperties
+    ) {
         $this->setUserId($userId);
         $this->setCount($count);
         $this->setScenario($scenario);
         $this->setRotationRate($rotationRate);
         $this->setRotationTime($rotationTime);
+        $this->setResponseProperties($responseProperties);
     }
 
     /**
@@ -53,6 +66,7 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
      * Set from 0.0 for no rotation (same items will be recommended) up to 1.0 (same items should not be recommended).
      * @param int $rotationTime Specify for how long will the item's rotationRate be taken in account and so the item
      * is penalized for recommendations.
+     * @param string[] $responseProperties Specify which properties you want to retrieve from matej alongside the item_id.
      * @return static
      */
     public static function create(
@@ -60,9 +74,10 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
         int $count,
         string $scenario,
         float $rotationRate,
-        int $rotationTime
+        int $rotationTime,
+        array $responseProperties = ['item_id']
     ): self {
-        return new static($userId, $count, $scenario, $rotationRate, $rotationTime);
+        return new static($userId, $count, $scenario, $rotationRate, $rotationTime, $responseProperties);
     }
 
     /**
@@ -119,6 +134,42 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
         Assertion::allString($filters);
 
         $this->filters = $filters;
+
+        return $this;
+    }
+
+    public function setFilterType(string $filterType): self
+    {
+        Assertion::typeIdentifier($filterType);
+
+        $this->filterType = $filterType;
+
+        return $this;
+    }
+
+    /**
+     * Specify which item property you want returned.
+     */
+    public function addResponseProperty(string $property): self
+    {
+        Assertion::typeIdentifier($property);
+
+        $this->responseProperties[] = $property;
+
+        return $this;
+    }
+
+    /**
+     * Overwrite all properties by custom specified list. Note that this will overried the defaults.
+     *
+     * @param string[] $properties
+     * @return $this
+     */
+    public function setResponseProperties(?array $properties): self
+    {
+        Assertion::allTypeIdentifier($properties);
+
+        $this->responseProperties = $properties;
 
         return $this;
     }
@@ -200,8 +251,16 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
             'filter' => $this->assembleFiltersString(),
         ];
 
+        if ($this->filterType !== self::FILTER_TYPE_RGX) {
+            $parameters['filter_type'] = $this->filterType;
+        }
+
         if ($this->modelName !== null) {
             $parameters['model_name'] = $this->modelName;
+        }
+
+        if ($this->responseProperties !== null) {
+            $parameters['properties'] = $this->responseProperties;
         }
 
         return $parameters;

--- a/tests/integration/RequestBuilder/RecommendationRequestBuilderTest.php
+++ b/tests/integration/RequestBuilder/RecommendationRequestBuilderTest.php
@@ -51,9 +51,28 @@ class RecommendationRequestBuilderTest extends IntegrationTestCase
         $this->expectExceptionCode(400);
         $this->expectExceptionMessage('BAD REQUEST');
 
+        $recommendation = $this->createRecommendationCommand('user-a')
+            ->setModelName('invalid-model-name');
+
         $this->createMatejInstance()
             ->request()
-            ->recommendation($this->createRecommendationCommand('user-a')->setModelName('invalid-model-name'))
+            ->recommendation($recommendation)
+            ->send();
+    }
+
+    /** @test */
+    public function shouldFailOnInvalidPropertyName(): void
+    {
+        $this->expectException(RequestException::class);
+        $this->expectExceptionCode(400);
+        $this->expectExceptionMessage('BAD REQUEST');
+
+        $recommendation = $this->createRecommendationCommand('user-a')
+            ->addResponseProperty('unknown-property');
+
+        $this->createMatejInstance()
+            ->request()
+            ->recommendation($recommendation)
             ->send();
     }
 

--- a/tests/unit/Http/Fixtures/response-recommendation-v1.json
+++ b/tests/unit/Http/Fixtures/response-recommendation-v1.json
@@ -1,0 +1,38 @@
+{
+  "commands": {
+    "number_of_commands": 3,
+    "number_of_failed_commands": 0,
+    "number_of_skipped_commands": 2,
+    "number_of_successful_commands": 1,
+    "responses": [
+      {
+        "data": [],
+        "message": "",
+        "status": "SKIPPED"
+      },
+      {
+        "data": [],
+        "message": "",
+        "status": "SKIPPED"
+      },
+      {
+        "data": [
+          "jd-5a2ebcb2fc13ae1fdb00016d",
+          "jd-5a2ebcb1fc13ae1fdb0000e3",
+          "jd-5a2ebcb2fc13ae1fdb000295",
+          "jd-5a2ebcb2fc13ae1fdb00022d",
+          "jd-5a2ebcb1fc13ae1fdb00010a",
+          "jd-5a2ebcb1fc13ae1fdb00010d",
+          "jd-5a2ebcb3fc13ae1fdb000389",
+          "jd-5a2ebcb3fc13ae1fdb000367",
+          "jd-5a2ebcb2fc13ae1fdb000285",
+          "jd-5a2ebcb2fc13ae1fdb0002cb"
+        ],
+        "message": "",
+        "status": "OK"
+      }
+    ]
+  },
+  "message": "",
+  "status": "OK"
+}

--- a/tests/unit/Http/Fixtures/response-recommendation-v2.json
+++ b/tests/unit/Http/Fixtures/response-recommendation-v2.json
@@ -1,0 +1,38 @@
+{
+  "commands": {
+    "number_of_commands": 3,
+    "number_of_failed_commands": 0,
+    "number_of_skipped_commands": 2,
+    "number_of_successful_commands": 1,
+    "responses": [
+      {
+        "data": [],
+        "message": "",
+        "status": "SKIPPED"
+      },
+      {
+        "data": [],
+        "message": "",
+        "status": "SKIPPED"
+      },
+      {
+        "data": [
+          {"item_id": "jd-5a2ebcb2fc13ae1fdb00016d", "item_url": "http://test-url/5a2ebcb2fc13ae1fdb00016d"},
+          {"item_id": "jd-5a2ebcb1fc13ae1fdb0000e3", "item_url": "http://test-url/5a2ebcb1fc13ae1fdb0000e3"},
+          {"item_id": "jd-5a2ebcb2fc13ae1fdb000295", "item_url": "http://test-url/5a2ebcb2fc13ae1fdb000295"},
+          {"item_id": "jd-5a2ebcb2fc13ae1fdb00022d", "item_url": "http://test-url/5a2ebcb2fc13ae1fdb00022d"},
+          {"item_id": "jd-5a2ebcb1fc13ae1fdb00010a", "item_url": "http://test-url/5a2ebcb1fc13ae1fdb00010a"},
+          {"item_id": "jd-5a2ebcb1fc13ae1fdb00010d", "item_url": "http://test-url/5a2ebcb1fc13ae1fdb00010d"},
+          {"item_id": "jd-5a2ebcb3fc13ae1fdb000389", "item_url": "http://test-url/5a2ebcb3fc13ae1fdb000389"},
+          {"item_id": "jd-5a2ebcb3fc13ae1fdb000367", "item_url": "http://test-url/5a2ebcb3fc13ae1fdb000367"},
+          {"item_id": "jd-5a2ebcb2fc13ae1fdb000285", "item_url": "http://test-url/5a2ebcb2fc13ae1fdb000285"},
+          {"item_id": "jd-5a2ebcb2fc13ae1fdb0002cb", "item_url": "http://test-url/5a2ebcb2fc13ae1fdb0002cb"}
+        ],
+        "message": "",
+        "status": "OK"
+      }
+    ]
+  },
+  "message": "",
+  "status": "OK"
+}


### PR DESCRIPTION
|  |  |
| --- | --- |
| **Type** | Feature |
| **Fixes issues** | RAD-1689 |
| **Documentation** | updated |
| **BC Break** | **YES** |
| **Tests updated** | yes |

Adds support for Matej Query Language in the recommendation requests, which is now default way of sending requests.

Removes default filter.

Legacy filtering using regexes can be done by setting filter type to `FILTER_TYPE_RGX`. In the request itself, the legacy way of filtering is implemented by _absence_ of parameter `filter_type`. However, we don't want to encourage Matej users to use the RGX filter, as MQL is overall faster, *and* implements more features. Therefore, I did not mention this explicitly in the documentation.