### PR TITLE
Change filtering language to MQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ## Unreleased
 ### Changed
 - **BC BREAK** | `UserRecommendation` now returns new format of response in `->getData()`, which is a list of `stdClass` instances.
+- **BC BREAK** | `UserRecommendation` does not have default filter (was previously set to: `valid_to >= NOW`).
+- **BC BREAK** | `UserRecommendation` now uses MQL query language by default for filtering.
 
 ### Fixed
 - Exceptions occurring during async request now generate rejected promise (as they should) and are no longer thrown directly.

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ You can also set more granular options of the recommendation command:
 
 ```php
 $recommendation = UserRecommendation::create('user-id', 5, 'test-scenario', 1.0, 3600);
-$recommendation->setFilters(['valid_to >= NOW']) // Note this filter is present by default
+$recommendation->setFilters(['for_recommendation = 1'])
     ->setMinimalRelevance(UserRecommendation::MINIMAL_RELEVANCE_HIGH)
     ->enableHardRotation();
 

--- a/src/Model/Command/UserRecommendation.php
+++ b/src/Model/Command/UserRecommendation.php
@@ -12,6 +12,7 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
     public const MINIMAL_RELEVANCE_LOW = 'low';
     public const MINIMAL_RELEVANCE_MEDIUM = 'medium';
     public const MINIMAL_RELEVANCE_HIGH = 'high';
+    public const FILTER_TYPE_MQL = 'mql';
 
     /** @var string */
     protected $filterOperator = 'and';
@@ -30,7 +31,9 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
     /** @var string */
     private $minimalRelevance = self::MINIMAL_RELEVANCE_LOW;
     /** @var string[] */
-    private $filters = ['valid_to >= NOW'];
+    private $filters = [];
+    /** @var string */
+    private $filterType = self::FILTER_TYPE_MQL;
     /** @var string|null */
     private $modelName = null;
     /** @var string[] */
@@ -236,6 +239,7 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
             'hard_rotation' => $this->hardRotation,
             'min_relevance' => $this->minimalRelevance,
             'filter' => $this->assembleFiltersString(),
+            'filter_type' => $this->filterType,
             'properties' => $this->responseProperties,
         ];
 


### PR DESCRIPTION
|  |  |
| --- | --- |
| **Type** | Feature |
| **Fixes issues** | RAD-1689 |
| **Documentation** | updated |
| **BC Break** | **YES** |
| **Tests updated** | yes |
| **Notes** | Requires #82 to be merged first. |

Adds support for Matej Query Language in the recommendation requests, which is now default way of sending requests.

Removes default filter.

Legacy filtering using regexes can be done by setting filter type to `FILTER_TYPE_RGX`. In the request itself, the legacy way of filtering is implemented by _absence_ of parameter `filter_type`. However, we don't want to encourage Matej users to use the RGX filter, as MQL is overall faster, *and* implements more features. Therefore, I did not mention this explicitly in the documentation.