### PR TITLE
Use Enums where applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - **BC BREAK** | `UserRecommendation` now returns new format of response in `->getData()`, which is a list of `stdClass` instances.
 - **BC BREAK** | `UserRecommendation` does not have default filter (was previously set to: `valid_to >= NOW`).
 - **BC BREAK** | `UserRecommendation` now uses MQL query language by default for filtering.
+- **BC BREAK** | Minimal relevance passed to `setMinimalRelevance()` method of `UserRecommendation` command must be of enum type `MinimalRelevance`.
+- **BC BREAK** | `getForgetMethod()` method of `UserForget` command now returns instance of `UserForgetMethod` enum instead of string.
 
 ### Fixed
 - Exceptions occurring during async request now generate rejected promise (as they should) and are no longer thrown directly.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ You can also set more granular options of the recommendation command:
 ```php
 $recommendation = UserRecommendation::create('user-id', 5, 'test-scenario', 1.0, 3600);
 $recommendation->setFilters(['for_recommendation = 1'])
-    ->setMinimalRelevance(UserRecommendation::MINIMAL_RELEVANCE_HIGH)
+    ->setMinimalRelevance(MinimalRelevance::HIGH())
     ->enableHardRotation();
 
 $response = $matej->request()

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "ext-json": "*",
         "beberlei/assert": "^2.8",
         "fig/http-message-util": "^1.1",
+        "myclabs/php-enum": "^1.6",
         "php-http/client-common": "^1.6",
         "php-http/client-implementation": "^1.0",
         "php-http/discovery": "^1.0",

--- a/src/Model/Command/Constants/InteractionType.php
+++ b/src/Model/Command/Constants/InteractionType.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model\Command\Constants;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * @method static InteractionType DETAILVIEWS()
+ * @method static InteractionType PURCHASES()
+ * @method static InteractionType BOOKMARKS()
+ * @method static InteractionType RATINGS()
+ */
+final class InteractionType extends Enum
+{
+    public const DETAILVIEWS = 'detailviews';
+    public const PURCHASES = 'purchases';
+    public const BOOKMARKS = 'bookmarks';
+    public const RATINGS = 'ratings';
+}

--- a/src/Model/Command/Constants/MinimalRelevance.php
+++ b/src/Model/Command/Constants/MinimalRelevance.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model\Command\Constants;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * @method static MinimalRelevance LOW()
+ * @method static MinimalRelevance MEDIUM()
+ * @method static MinimalRelevance HIGH()
+ */
+final class MinimalRelevance extends Enum
+{
+    public const LOW = 'low';
+    public const MEDIUM = 'medium';
+    public const HIGH = 'high';
+}

--- a/src/Model/Command/Constants/PropertyType.php
+++ b/src/Model/Command/Constants/PropertyType.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model\Command\Constants;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * @method static PropertyType INT()
+ * @method static PropertyType DOUBLE()
+ * @method static PropertyType STRING()
+ * @method static PropertyType BOOLEAN()
+ * @method static PropertyType TIMESTAMP()
+ * @method static PropertyType SET()
+ */
+final class PropertyType extends Enum
+{
+    public const INT = 'int';
+    public const DOUBLE = 'double';
+    public const STRING = 'string';
+    public const BOOLEAN = 'boolean';
+    public const TIMESTAMP = 'timestamp';
+    public const SET = 'set';
+}

--- a/src/Model/Command/Constants/UserForgetMethod.php
+++ b/src/Model/Command/Constants/UserForgetMethod.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\Model\Command\Constants;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * @method static UserForgetMethod ANONYMIZE()
+ * @method static UserForgetMethod DELETE()
+ */
+final class UserForgetMethod extends Enum
+{
+    public const ANONYMIZE = 'anonymize';
+    public const DELETE = 'delete';
+}

--- a/src/Model/Command/Interaction.php
+++ b/src/Model/Command/Interaction.php
@@ -3,6 +3,7 @@
 namespace Lmc\Matej\Model\Command;
 
 use Lmc\Matej\Model\Assertion;
+use Lmc\Matej\Model\Command\Constants\InteractionType;
 
 /**
  * Interaction command allows to send one interaction between a user and item.
@@ -10,12 +11,7 @@ use Lmc\Matej\Model\Assertion;
  */
 class Interaction extends AbstractCommand implements UserAwareInterface
 {
-    private const INTERACTION_TYPE_DETAILVIEWS = 'detailviews';
-    private const INTERACTION_TYPE_PURCHASES = 'purchases';
-    private const INTERACTION_TYPE_BOOKMARKS = 'bookmarks';
-    private const INTERACTION_TYPE_RATINGS = 'ratings';
-
-    /** @var string */
+    /** @var InteractionType */
     private $interactionType;
     /** @var string */
     private $userId;
@@ -29,7 +25,7 @@ class Interaction extends AbstractCommand implements UserAwareInterface
     private $timestamp;
 
     private function __construct(
-        string $interactionType,
+        InteractionType $interactionType,
         string $userId,
         string $itemId,
         float $value = 1.0,
@@ -57,7 +53,7 @@ class Interaction extends AbstractCommand implements UserAwareInterface
         string $context = 'default',
         int $timestamp = null
     ): self {
-        return new static(self::INTERACTION_TYPE_DETAILVIEWS, $userId, $itemId, $value, $context, $timestamp);
+        return new static(InteractionType::DETAILVIEWS(), $userId, $itemId, $value, $context, $timestamp);
     }
 
     /**
@@ -74,7 +70,7 @@ class Interaction extends AbstractCommand implements UserAwareInterface
         string $context = 'default',
         int $timestamp = null
     ): self {
-        return new static(self::INTERACTION_TYPE_PURCHASES, $userId, $itemId, $value, $context, $timestamp);
+        return new static(InteractionType::PURCHASES(), $userId, $itemId, $value, $context, $timestamp);
     }
 
     /**
@@ -95,7 +91,7 @@ class Interaction extends AbstractCommand implements UserAwareInterface
         string $context = 'default',
         int $timestamp = null
     ): self {
-        return new static(self::INTERACTION_TYPE_BOOKMARKS, $userId, $itemId, $value, $context, $timestamp);
+        return new static(InteractionType::BOOKMARKS(), $userId, $itemId, $value, $context, $timestamp);
     }
 
     /**
@@ -112,7 +108,7 @@ class Interaction extends AbstractCommand implements UserAwareInterface
         string $context = 'default',
         int $timestamp = null
     ): self {
-        return new static(self::INTERACTION_TYPE_RATINGS, $userId, $itemId, $value, $context, $timestamp);
+        return new static(InteractionType::RATINGS(), $userId, $itemId, $value, $context, $timestamp);
     }
 
     public function getUserId(): string
@@ -128,7 +124,7 @@ class Interaction extends AbstractCommand implements UserAwareInterface
     public function getCommandParameters(): array
     {
         return [
-            'interaction_type' => $this->interactionType,
+            'interaction_type' => $this->interactionType->jsonSerialize(),
             'user_id' => $this->userId,
             'item_id' => $this->itemId,
             'timestamp' => $this->timestamp,

--- a/src/Model/Command/ItemPropertySetup.php
+++ b/src/Model/Command/ItemPropertySetup.php
@@ -3,25 +3,19 @@
 namespace Lmc\Matej\Model\Command;
 
 use Lmc\Matej\Model\Assertion;
+use Lmc\Matej\Model\Command\Constants\PropertyType;
 
 /**
  * Command to add or delete item property in the database.
  */
 class ItemPropertySetup extends AbstractCommand
 {
-    const PROPERTY_TYPE_INT = 'int';
-    const PROPERTY_TYPE_DOUBLE = 'double';
-    const PROPERTY_TYPE_STRING = 'string';
-    const PROPERTY_TYPE_BOOLEAN = 'boolean';
-    const PROPERTY_TYPE_TIMESTAMP = 'timestamp';
-    const PROPERTY_TYPE_SET = 'set';
-
     /** @var string */
     private $propertyName;
-    /** @var string */
+    /** @var PropertyType */
     private $propertyType;
 
-    private function __construct(string $propertyName, string $propertyType)
+    private function __construct(string $propertyName, PropertyType $propertyType)
     {
         $this->setPropertyName($propertyName);
         $this->propertyType = $propertyType;
@@ -30,37 +24,37 @@ class ItemPropertySetup extends AbstractCommand
     /** @return static */
     public static function int(string $propertyName): self
     {
-        return new static($propertyName, static::PROPERTY_TYPE_INT);
+        return new static($propertyName, PropertyType::INT());
     }
 
     /** @return static */
     public static function double(string $propertyName): self
     {
-        return new static($propertyName, static::PROPERTY_TYPE_DOUBLE);
+        return new static($propertyName, PropertyType::DOUBLE());
     }
 
     /** @return static */
     public static function string(string $propertyName): self
     {
-        return new static($propertyName, static::PROPERTY_TYPE_STRING);
+        return new static($propertyName, PropertyType::STRING());
     }
 
     /** @return static */
     public static function boolean(string $propertyName): self
     {
-        return new static($propertyName, static::PROPERTY_TYPE_BOOLEAN);
+        return new static($propertyName, PropertyType::BOOLEAN());
     }
 
     /** @return static */
     public static function timestamp(string $propertyName): self
     {
-        return new static($propertyName, static::PROPERTY_TYPE_TIMESTAMP);
+        return new static($propertyName, PropertyType::TIMESTAMP());
     }
 
     /** @return static */
     public static function set(string $propertyName): self
     {
-        return new static($propertyName, static::PROPERTY_TYPE_SET);
+        return new static($propertyName, PropertyType::SET());
     }
 
     protected function setPropertyName(string $propertyName): void
@@ -84,7 +78,7 @@ class ItemPropertySetup extends AbstractCommand
     {
         return [
             'property_name' => $this->propertyName,
-            'property_type' => $this->propertyType,
+            'property_type' => $this->propertyType->jsonSerialize(),
         ];
     }
 }

--- a/src/Model/Command/Sorting.php
+++ b/src/Model/Command/Sorting.php
@@ -15,7 +15,7 @@ class Sorting extends AbstractCommand implements UserAwareInterface
     /** @var string[] */
     private $itemIds = [];
     /** @var string|null */
-    private $modelName = null;
+    private $modelName;
 
     private function __construct(string $userId, array $itemIds)
     {

--- a/src/Model/Command/UserForget.php
+++ b/src/Model/Command/UserForget.php
@@ -3,6 +3,7 @@
 namespace Lmc\Matej\Model\Command;
 
 use Lmc\Matej\Model\Assertion;
+use Lmc\Matej\Model\Command\Constants\UserForgetMethod;
 
 /**
  * UserForget any user in Matej, either by anonymizing or by deleting their entries.
@@ -11,18 +12,15 @@ use Lmc\Matej\Model\Assertion;
  */
 class UserForget extends AbstractCommand implements UserAwareInterface
 {
-    public const ANONYMIZE = 'anonymize';
-    public const DELETE = 'delete';
-
     /** @var string */
     private $userId;
-    /** @var string */
+    /** @var UserForgetMethod */
     private $method;
 
-    private function __construct(string $userId, string $method)
+    private function __construct(string $userId, UserForgetMethod $method)
     {
         $this->setUserId($userId);
-        $this->setForgetMethod($method);
+        $this->method = $method;
     }
 
     /**
@@ -30,7 +28,7 @@ class UserForget extends AbstractCommand implements UserAwareInterface
      */
     public static function anonymize(string $userId): self
     {
-        return new static($userId, self::ANONYMIZE);
+        return new static($userId, UserForgetMethod::ANONYMIZE());
     }
 
     /**
@@ -38,7 +36,7 @@ class UserForget extends AbstractCommand implements UserAwareInterface
      */
     public static function delete(string $userId): self
     {
-        return new static($userId, self::DELETE);
+        return new static($userId, UserForgetMethod::DELETE());
     }
 
     public function getUserId(): string
@@ -46,7 +44,7 @@ class UserForget extends AbstractCommand implements UserAwareInterface
         return $this->userId;
     }
 
-    public function getForgetMethod(): string
+    public function getForgetMethod(): UserForgetMethod
     {
         return $this->method;
     }
@@ -58,13 +56,6 @@ class UserForget extends AbstractCommand implements UserAwareInterface
         $this->userId = $userId;
     }
 
-    protected function setForgetMethod(string $method): void
-    {
-        Assertion::choice($method, [self::ANONYMIZE, self::DELETE]);
-
-        $this->method = $method;
-    }
-
     protected function getCommandType(): string
     {
         return 'user-forget';
@@ -74,7 +65,7 @@ class UserForget extends AbstractCommand implements UserAwareInterface
     {
         return [
             'user_id' => $this->userId,
-            'method' => $this->method,
+            'method' => $this->method->jsonSerialize(),
         ];
     }
 }

--- a/src/Model/Command/UserRecommendation.php
+++ b/src/Model/Command/UserRecommendation.php
@@ -3,15 +3,13 @@
 namespace Lmc\Matej\Model\Command;
 
 use Lmc\Matej\Model\Assertion;
+use Lmc\Matej\Model\Command\Constants\MinimalRelevance;
 
 /**
  * Deliver personalized recommendations for the given user.
  */
 class UserRecommendation extends AbstractCommand implements UserAwareInterface
 {
-    public const MINIMAL_RELEVANCE_LOW = 'low';
-    public const MINIMAL_RELEVANCE_MEDIUM = 'medium';
-    public const MINIMAL_RELEVANCE_HIGH = 'high';
     public const FILTER_TYPE_MQL = 'mql';
 
     /** @var string */
@@ -28,14 +26,14 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
     private $rotationTime;
     /** @var bool */
     private $hardRotation = false;
-    /** @var string */
-    private $minimalRelevance = self::MINIMAL_RELEVANCE_LOW;
+    /** @var MinimalRelevance */
+    private $minimalRelevance;
     /** @var string[] */
     private $filters = [];
     /** @var string */
     private $filterType = self::FILTER_TYPE_MQL;
     /** @var string|null */
-    private $modelName = null;
+    private $modelName;
     /** @var string[] */
     private $responseProperties = [];
 
@@ -47,6 +45,8 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
         int $rotationTime,
         array $responseProperties
     ) {
+        $this->minimalRelevance = MinimalRelevance::LOW();
+
         $this->setUserId($userId);
         $this->setCount($count);
         $this->setScenario($scenario);
@@ -99,13 +99,8 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
      *
      * @return $this
      */
-    public function setMinimalRelevance(string $minimalRelevance): self
+    public function setMinimalRelevance(MinimalRelevance $minimalRelevance): self
     {
-        Assertion::choice(
-            $minimalRelevance,
-            [static::MINIMAL_RELEVANCE_LOW, static::MINIMAL_RELEVANCE_MEDIUM, static::MINIMAL_RELEVANCE_HIGH]
-        );
-
         $this->minimalRelevance = $minimalRelevance;
 
         return $this;
@@ -237,7 +232,7 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
             'rotation_rate' => $this->rotationRate,
             'rotation_time' => $this->rotationTime,
             'hard_rotation' => $this->hardRotation,
-            'min_relevance' => $this->minimalRelevance,
+            'min_relevance' => $this->minimalRelevance->jsonSerialize(),
             'filter' => $this->assembleFiltersString(),
             'filter_type' => $this->filterType,
             'properties' => $this->responseProperties,

--- a/tests/unit/Model/Command/ItemPropertySetupTest.php
+++ b/tests/unit/Model/Command/ItemPropertySetupTest.php
@@ -3,6 +3,7 @@
 namespace Lmc\Matej\Model\Command;
 
 use Lmc\Matej\Exception\DomainException;
+use Lmc\Matej\Model\Command\Constants\PropertyType;
 use PHPUnit\Framework\TestCase;
 
 class ItemPropertySetupTest extends TestCase
@@ -50,12 +51,12 @@ class ItemPropertySetupTest extends TestCase
     public function provideConstructorName(): array
     {
         return [
-            ['int', ItemPropertySetup::PROPERTY_TYPE_INT],
-            ['double', ItemPropertySetup::PROPERTY_TYPE_DOUBLE],
-            ['string', ItemPropertySetup::PROPERTY_TYPE_STRING],
-            ['boolean', ItemPropertySetup::PROPERTY_TYPE_BOOLEAN],
-            ['timestamp', ItemPropertySetup::PROPERTY_TYPE_TIMESTAMP],
-            ['set', ItemPropertySetup::PROPERTY_TYPE_SET],
+            ['int', PropertyType::INT],
+            ['double', PropertyType::DOUBLE],
+            ['string', PropertyType::STRING],
+            ['boolean', PropertyType::BOOLEAN],
+            ['timestamp', PropertyType::TIMESTAMP],
+            ['set', PropertyType::SET],
         ];
     }
 }

--- a/tests/unit/Model/Command/UserForgetTest.php
+++ b/tests/unit/Model/Command/UserForgetTest.php
@@ -2,6 +2,7 @@
 
 namespace Lmc\Matej\Model\Command;
 
+use Lmc\Matej\Model\Command\Constants\UserForgetMethod;
 use Lmc\Matej\UnitTestCase;
 
 class UserForgetTest extends UnitTestCase
@@ -12,10 +13,10 @@ class UserForgetTest extends UnitTestCase
         $userId = 'user-id';
 
         $command = UserForget::anonymize($userId);
-        $this->assertForgetCommand($command, $userId, UserForget::ANONYMIZE);
+        $this->assertForgetCommand($command, $userId, UserForgetMethod::ANONYMIZE());
 
         $command = UserForget::delete($userId);
-        $this->assertForgetCommand($command, $userId, UserForget::DELETE);
+        $this->assertForgetCommand($command, $userId, UserForgetMethod::DELETE());
     }
 
     /**
@@ -23,7 +24,7 @@ class UserForgetTest extends UnitTestCase
      *
      * @param UserForget $command
      */
-    private function assertForgetCommand($command, string $userId, string $method): void
+    private function assertForgetCommand($command, string $userId, UserForgetMethod $method): void
     {
         $this->assertInstanceOf(UserForget::class, $command);
         $this->assertSame(
@@ -31,12 +32,12 @@ class UserForgetTest extends UnitTestCase
                 'type' => 'user-forget',
                 'parameters' => [
                     'user_id' => $userId,
-                    'method' => $method,
+                    'method' => $method->jsonSerialize(),
                 ],
             ],
             $command->jsonSerialize()
         );
         $this->assertSame($userId, $command->getUserId());
-        $this->assertSame($method, $command->getForgetMethod());
+        $this->assertEquals($method, $command->getForgetMethod());
     }
 }

--- a/tests/unit/Model/Command/UserRecommendationTest.php
+++ b/tests/unit/Model/Command/UserRecommendationTest.php
@@ -2,6 +2,7 @@
 
 namespace Lmc\Matej\Model\Command;
 
+use Lmc\Matej\Model\Command\Constants\MinimalRelevance;
 use PHPUnit\Framework\TestCase;
 
 class UserRecommendationTest extends TestCase
@@ -22,7 +23,7 @@ class UserRecommendationTest extends TestCase
                     'rotation_rate' => 1.0,
                     'rotation_time' => 3600,
                     'hard_rotation' => false,
-                    'min_relevance' => UserRecommendation::MINIMAL_RELEVANCE_LOW,
+                    'min_relevance' => MinimalRelevance::LOW,
                     'filter' => '',
                     'filter_type' => UserRecommendation::FILTER_TYPE_MQL,
                     'properties' => [],
@@ -46,7 +47,7 @@ class UserRecommendationTest extends TestCase
 
         $command = UserRecommendation::create($userId, $count, $scenario, $rotationRate, $rotationTime);
 
-        $command->setMinimalRelevance(UserRecommendation::MINIMAL_RELEVANCE_HIGH)
+        $command->setMinimalRelevance(MinimalRelevance::HIGH())
             ->enableHardRotation()
             ->setFilters(['foo = bar', 'baz = ban'])
             ->setModelName($modelName);
@@ -62,7 +63,7 @@ class UserRecommendationTest extends TestCase
                     'rotation_rate' => $rotationRate,
                     'rotation_time' => $rotationTime,
                     'hard_rotation' => true,
-                    'min_relevance' => UserRecommendation::MINIMAL_RELEVANCE_HIGH,
+                    'min_relevance' => MinimalRelevance::HIGH,
                     'filter' => 'foo = bar and baz = ban',
                     'filter_type' => UserRecommendation::FILTER_TYPE_MQL,
                     'properties' => [],


### PR DESCRIPTION
Instead of relying on constants with strings (and checking if proper value was used using Assertion::choice) we use [php-enum](https://github.com/myclabs/php-enum) library. 

Benefit is also code completion in IDE, which will thanks to typehint offer all possible values.

![obrazek](https://user-images.githubusercontent.com/793041/44939239-f3f46000-ad83-11e8-9e12-3026163ce47a.png)

Even though this is BC break, the upgrade is quite easy (and it affect only those using `setMinimalMethod`). Enums are now used on multiple places, but public interface is affected only for this method.

### Before
```php
$recommendation = UserRecommendation::create('user-id', 1, 'scenario', 1.0, 3600);
$recommendation->setMinimalRelevance(UserRecommendation::MINIMAL_RELEVANCE_HIGH);
```

### After
```php
use Lmc\Matej\Model\Command\Constants\MinimalRelevance;
...
$recommendation = UserRecommendation::create('user-id', 1, 'scenario', 1.0, 3600);
$recommendation->setMinimalRelevance(MinimalRelevance::HIGH());
```