### PR TITLE
Add support for allow_seen in Recommendation requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## Unreleased
 
+### Added
+- `UserRecommendation` has new method `setAllowSeen(true|false)`, which allows recommending of already visited items.
+
 ## 2.0.0 - 2018-09-04
 See [UPGRADE-2.0.md](UPGRADE-2.0.md) for upgrade instructions.
 

--- a/src/Model/Command/UserRecommendation.php
+++ b/src/Model/Command/UserRecommendation.php
@@ -36,6 +36,8 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
     private $modelName;
     /** @var string[] */
     private $responseProperties = [];
+    /** @var bool */
+    private $allowSeen = false;
 
     private function __construct(
         string $userId,
@@ -173,6 +175,20 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
         return $this;
     }
 
+    /**
+     * Allow items, that the user has already "seen"
+     *
+     * By default user won't see any items, that it has visitted (and we have recorded DetailView interaction.)
+     * If you want to circumvent this, and get recommendations including the ones, that the user has already visitted,
+     * you can set the "seen" allowance here.
+     */
+    public function setAllowSeen(bool $seen): self
+    {
+        $this->allowSeen = $seen;
+
+        return $this;
+    }
+
     public function getUserId(): string
     {
         return $this->userId;
@@ -240,6 +256,10 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
 
         if ($this->modelName !== null) {
             $parameters['model_name'] = $this->modelName;
+        }
+
+        if ($this->allowSeen !== false) {
+            $parameters['allow_seen'] = $this->allowSeen;
         }
 
         return $parameters;

--- a/tests/unit/Model/Command/UserRecommendationTest.php
+++ b/tests/unit/Model/Command/UserRecommendationTest.php
@@ -28,6 +28,7 @@ class UserRecommendationTest extends TestCase
                     'filter_type' => UserRecommendation::FILTER_TYPE_MQL,
                     'properties' => [],
                     // when using default model name, parameter "model_name" should be absent.
+                    // by default, allow_seen is absent
                 ],
             ],
             $command->jsonSerialize()
@@ -50,7 +51,8 @@ class UserRecommendationTest extends TestCase
         $command->setMinimalRelevance(MinimalRelevance::HIGH())
             ->enableHardRotation()
             ->setFilters(['foo = bar', 'baz = ban'])
-            ->setModelName($modelName);
+            ->setModelName($modelName)
+            ->setAllowSeen(true);
 
         $this->assertInstanceOf(UserRecommendation::class, $command);
         $this->assertSame(
@@ -68,6 +70,7 @@ class UserRecommendationTest extends TestCase
                     'filter_type' => UserRecommendation::FILTER_TYPE_MQL,
                     'properties' => [],
                     'model_name' => $modelName,
+                    'allow_seen' => true,
                 ],
             ],
             $command->jsonSerialize()


### PR DESCRIPTION
|  |  |
| --- | --- |
| **Type** | Feature |
| **Fixes issues** | RAD-1735 |
| **Requires Matej** | `>= 7.46.0` |
| **Documentation** | updated |
| **BC Break** | No |
| **Tests updated** | yes |
| **Notes** | n/a |

By default, "seen" is any item, that the user has DetailView'ed. This however, can be changed for any given model, so "seen" can mean different things in `default` and `gamma` model for any particular client.