### PR TITLE
Add new item property type geolocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+### Added
+- New item property type `geolocation`
 
 ## 2.1.0 - 2018-09-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Unreleased
 ### Added
-- New item property type `geolocation`
+- New item property type `geolocation`.
 
 ## 2.1.0 - 2018-09-21
 ### Fixed

--- a/src/Model/Command/Constants/PropertyType.php
+++ b/src/Model/Command/Constants/PropertyType.php
@@ -11,6 +11,7 @@ use MyCLabs\Enum\Enum;
  * @method static PropertyType BOOLEAN()
  * @method static PropertyType TIMESTAMP()
  * @method static PropertyType SET()
+ * @method static PropertyType GEOLOCATION()
  */
 final class PropertyType extends Enum
 {
@@ -20,4 +21,5 @@ final class PropertyType extends Enum
     public const BOOLEAN = 'boolean';
     public const TIMESTAMP = 'timestamp';
     public const SET = 'set';
+    public const GEOLOCATION = 'geolocation';
 }

--- a/src/Model/Command/ItemPropertySetup.php
+++ b/src/Model/Command/ItemPropertySetup.php
@@ -57,6 +57,12 @@ class ItemPropertySetup extends AbstractCommand
         return new static($propertyName, PropertyType::SET());
     }
 
+    /** @return static */
+    public static function geolocation(string $propertyName): self
+    {
+        return new static($propertyName, PropertyType::GEOLOCATION());
+    }
+
     protected function setPropertyName(string $propertyName): void
     {
         Assertion::typeIdentifier($propertyName);

--- a/tests/unit/Model/Command/ItemPropertySetupTest.php
+++ b/tests/unit/Model/Command/ItemPropertySetupTest.php
@@ -57,6 +57,7 @@ class ItemPropertySetupTest extends TestCase
             ['boolean', PropertyType::BOOLEAN],
             ['timestamp', PropertyType::TIMESTAMP],
             ['set', PropertyType::SET],
+            ['geolocation', PropertyType::GEOLOCATION],
         ];
     }
 }


### PR DESCRIPTION
|  |  |
| --- | --- |
| **Type** | Feature |
| **Fixes issues** | RAD-1822 |
| **Requires Matej** | `>= 7.47.0` |
| **Documentation** | updated |
| **BC Break** | No |
| **Tests updated** | yes |
| **Notes** | n/a |

New item property type `geolocation` is required for using new operator `near` https://admin.matej.lmc.cz/docs/query_language.html#geolocation.

This item property is `composite` type. So question is if we should validate it's value?