### PR TITLE
Upgrade beberlei/assert to v3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": "^7.1",
         "ext-hash": "*",
         "ext-json": "*",
-        "beberlei/assert": "^2.8",
+        "beberlei/assert": "^3.1",
         "fig/http-message-util": "^1.1",
         "myclabs/php-enum": "^1.6",
         "php-http/client-common": "^1.6",


### PR DESCRIPTION
The only BC is dropped support of PHP < 7.0

https://github.com/beberlei/assert/blob/master/CHANGELOG.md