### PR TITLE
Update exception handling to new Matej behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ### Changed
 - Invalid command inside recommendation/sorting request does not cause whole request to fail, rather the specific command response is marked as invalid.
 - Deprecated `CommandResponse::STATUS_ERROR`, because Matej no longer uses it (`CommandResponse::STATUS_INVALID` is instead used everywhere).
+- Method `CommandResponse::isSuccessfull()` now returns true even for not only OK but also SKIPPED (ie. not invalid) statuses.
+This also means `Response::getNumberOfSuccessfulCommands()` now won't necessarily return the same number of command responses that return true on `CommandResponse::isSuccessful()`.
 
 ## 2.2.0 - 2018-10-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+### Changed
+- Invalid command inside recommendation/sorting request does not cause whole request to fail, rather the specific command response is marked as invalid.
+- Deprecated `CommandResponse::STATUS_ERROR`, because Matej no longer uses it (`CommandResponse::STATUS_INVALID` is instead used everywhere).
 
 ## 2.2.0 - 2018-10-02
 ### Added

--- a/src/Model/CommandResponse.php
+++ b/src/Model/CommandResponse.php
@@ -10,6 +10,7 @@ use Lmc\Matej\Exception\ResponseDecodingException;
 class CommandResponse
 {
     public const STATUS_OK = 'OK';
+    /** @deprecated */
     public const STATUS_ERROR = 'ERROR';
     public const STATUS_SKIPPED = 'SKIPPED';
     public const STATUS_INVALID = 'INVALID';

--- a/src/Model/CommandResponse.php
+++ b/src/Model/CommandResponse.php
@@ -56,8 +56,15 @@ class CommandResponse
         return $this->data;
     }
 
+    /**
+     * Use this method to check whether this command response did not fail. Note both OK and SKIPPED statuses
+     * are in fact marked as successful to provide this "command did not fail" detection.
+     * This also means `Response::getNumberOfSuccessfulCommands()` don't necessarily return the same number of
+     * command responses that return true on `CommandResponse::isSuccessful()` (as skipped command responses are
+     * reported separately in `Response::getNumberOfSkippedCommands()`).
+     */
     public function isSuccessful(): bool
     {
-        return $this->getStatus() === static::STATUS_OK;
+        return $this->getStatus() === static::STATUS_OK || $this->getStatus() === static::STATUS_SKIPPED;
     }
 }

--- a/tests/integration/IntegrationTestCase.php
+++ b/tests/integration/IntegrationTestCase.php
@@ -36,7 +36,7 @@ class IntegrationTestCase extends TestCase
     {
         $this->assertSame(count($expectedCommandStatuses), $response->getNumberOfCommands());
         $this->assertSame(count(array_intersect($expectedCommandStatuses, ['OK'])), $response->getNumberOfSuccessfulCommands());
-        $this->assertSame(count(array_intersect($expectedCommandStatuses, ['ERROR'])), $response->getNumberOfFailedCommands());
+        $this->assertSame(count(array_intersect($expectedCommandStatuses, ['INVALID'])), $response->getNumberOfFailedCommands());
         $this->assertSame(count(array_intersect($expectedCommandStatuses, ['SKIPPED'])), $response->getNumberOfSkippedCommands());
 
         $commandResponses = $response->getCommandResponses();

--- a/tests/integration/RequestBuilder/RecommendationRequestBuilderTest.php
+++ b/tests/integration/RequestBuilder/RecommendationRequestBuilderTest.php
@@ -2,7 +2,6 @@
 
 namespace Lmc\Matej\IntegrationTests\RequestBuilder;
 
-use Lmc\Matej\Exception\RequestException;
 use Lmc\Matej\IntegrationTests\IntegrationTestCase;
 use Lmc\Matej\Model\Command\Interaction;
 use Lmc\Matej\Model\Command\UserMerge;
@@ -45,35 +44,35 @@ class RecommendationRequestBuilderTest extends IntegrationTestCase
     }
 
     /** @test */
-    public function shouldFailOnInvalidModelName(): void
+    public function shouldReturnInvalidCommandOnInvalidModelName(): void
     {
-        $this->expectException(RequestException::class);
-        $this->expectExceptionCode(400);
-        $this->expectExceptionMessage('BAD REQUEST');
-
         $recommendation = $this->createRecommendationCommand('user-a')
             ->setModelName('invalid-model-name');
 
-        static::createMatejInstance()
+        $response = static::createMatejInstance()
             ->request()
             ->recommendation($recommendation)
             ->send();
+
+        $this->assertInstanceOf(RecommendationsResponse::class, $response);
+        $this->assertResponseCommandStatuses($response, 'SKIPPED', 'SKIPPED', 'INVALID');
+        $this->assertShorthandResponse($response, 'SKIPPED', 'SKIPPED', 'INVALID');
     }
 
     /** @test */
-    public function shouldFailOnInvalidPropertyName(): void
+    public function shouldReturnInvalidCommandOnInvalidPropertyName(): void
     {
-        $this->expectException(RequestException::class);
-        $this->expectExceptionCode(400);
-        $this->expectExceptionMessage('BAD REQUEST');
-
         $recommendation = $this->createRecommendationCommand('user-a')
             ->addResponseProperty('unknown-property');
 
-        static::createMatejInstance()
+        $response = static::createMatejInstance()
             ->request()
             ->recommendation($recommendation)
             ->send();
+
+        $this->assertInstanceOf(RecommendationsResponse::class, $response);
+        $this->assertResponseCommandStatuses($response, 'SKIPPED', 'SKIPPED', 'INVALID');
+        $this->assertShorthandResponse($response, 'SKIPPED', 'SKIPPED', 'INVALID');
     }
 
     private function createRecommendationCommand(string $username): UserRecommendation

--- a/tests/integration/RequestBuilder/SortingRequestTest.php
+++ b/tests/integration/RequestBuilder/SortingRequestTest.php
@@ -2,7 +2,6 @@
 
 namespace Lmc\Matej\IntegrationTests\RequestBuilder;
 
-use Lmc\Matej\Exception\RequestException;
 use Lmc\Matej\IntegrationTests\IntegrationTestCase;
 use Lmc\Matej\Model\Command\Interaction;
 use Lmc\Matej\Model\Command\Sorting;
@@ -45,16 +44,16 @@ class SortingRequestTest extends IntegrationTestCase
     }
 
     /** @test */
-    public function shouldFailOnInvalidModelName(): void
+    public function shouldReturnInvalidCommandOnInvalidModelName(): void
     {
-        $this->expectException(RequestException::class);
-        $this->expectExceptionCode(400);
-        $this->expectExceptionMessage('BAD REQUEST');
-
-        static::createMatejInstance()
+        $response = static::createMatejInstance()
             ->request()
             ->sorting(Sorting::create('user-b', ['item-a', 'item-b', 'itemC-c'])->setModelName('invalid-model-name'))
             ->send();
+
+        $this->assertInstanceOf(SortingResponse::class, $response);
+        $this->assertResponseCommandStatuses($response, 'SKIPPED', 'SKIPPED', 'INVALID');
+        $this->assertShorthandResponse($response, 'SKIPPED', 'SKIPPED', 'INVALID');
     }
 
     private function assertShorthandResponse(SortingResponse $response, $interactionStatus, $userMergeStatus, $sortingStatus): void

--- a/tests/unit/Http/Fixtures/response-item-properties.json
+++ b/tests/unit/Http/Fixtures/response-item-properties.json
@@ -13,7 +13,7 @@
       {
         "data": [],
         "message": "DuplicateKeyError(u'E11000 duplicate key error collection: foo.data_items_properties index: property_1 dup key: { : \"title\" }',)",
-        "status": "ERROR"
+        "status": "INVALID"
       },
       {
         "data": [],

--- a/tests/unit/Http/ResponseDecoderTest.php
+++ b/tests/unit/Http/ResponseDecoderTest.php
@@ -69,7 +69,7 @@ class ResponseDecoderTest extends UnitTestCase
         $this->assertCount(3, $commandResponses);
         $this->assertContainsOnlyInstancesOf(CommandResponse::class, $commandResponses);
         $this->assertSame(CommandResponse::STATUS_OK, $commandResponses[0]->getStatus());
-        $this->assertSame(CommandResponse::STATUS_ERROR, $commandResponses[1]->getStatus());
+        $this->assertSame(CommandResponse::STATUS_INVALID, $commandResponses[1]->getStatus());
         $this->assertSame(CommandResponse::STATUS_OK, $commandResponses[2]->getStatus());
     }
 

--- a/tests/unit/Model/CommandResponseTest.php
+++ b/tests/unit/Model/CommandResponseTest.php
@@ -54,8 +54,8 @@ class CommandResponseTest extends UnitTestCase
                 [['foo' => 'bar'], ['baz' => 'bak']],
             ],
             'Invalid error response with status and message' => [
-                (object) ['status' => CommandResponse::STATUS_ERROR, 'message' => 'Internal unhandled error'],
-                CommandResponse::STATUS_ERROR,
+                (object) ['status' => CommandResponse::STATUS_INVALID, 'message' => 'Internal unhandled error'],
+                CommandResponse::STATUS_INVALID,
                 'Internal unhandled error',
                 [],
             ],
@@ -80,7 +80,6 @@ class CommandResponseTest extends UnitTestCase
     {
         return [
             ['status' => CommandResponse::STATUS_OK, 'isSuccessful' => true],
-            ['status' => CommandResponse::STATUS_ERROR, 'isSuccessful' => false],
             ['status' => CommandResponse::STATUS_INVALID, 'isSuccessful' => false],
             ['status' => CommandResponse::STATUS_SKIPPED, 'isSuccessful' => false]  ,
         ];

--- a/tests/unit/Model/CommandResponseTest.php
+++ b/tests/unit/Model/CommandResponseTest.php
@@ -81,7 +81,7 @@ class CommandResponseTest extends UnitTestCase
         return [
             ['status' => CommandResponse::STATUS_OK, 'isSuccessful' => true],
             ['status' => CommandResponse::STATUS_INVALID, 'isSuccessful' => false],
-            ['status' => CommandResponse::STATUS_SKIPPED, 'isSuccessful' => false]  ,
+            ['status' => CommandResponse::STATUS_SKIPPED, 'isSuccessful' => true]  ,
         ];
     }
 

--- a/tests/unit/Model/ResponseTest.php
+++ b/tests/unit/Model/ResponseTest.php
@@ -52,7 +52,7 @@ class ResponseTest extends UnitTestCase
     public function provideResponseData(): array
     {
         $okCommandResponse = (object) ['status' => CommandResponse::STATUS_OK, 'message' => '', 'data' => []];
-        $failedCommandResponse = (object) ['status' => CommandResponse::STATUS_ERROR, 'message' => 'KO', 'data' => []];
+        $failedCommandResponse = (object) ['status' => CommandResponse::STATUS_INVALID, 'message' => 'KO', 'data' => []];
         $skippedCommandResponse = (object) ['status' => CommandResponse::STATUS_SKIPPED, 'message' => '', 'data' => []];
 
         return [


### PR DESCRIPTION
Invalid command inside recommendation/sorting request does not cause whole request to fail, rather the specific failed command status is `CommandResponse::STATUS_INVALID`.
The current Matej behavior (failing the whole Recommendation/Sorting request by its http response code) is inconsistent with Events endpoint and also with Matej own documentation ¯\\\_(ツ)_/¯.


The new behavior covered by this pull request will be part of upcoming Matej 7.56 (see RAD-2157 for the release and RAD-1806 for implementation details).