### PR TITLE
Add isSuccessful() method to Response 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+### Added
+- Method `isSuccessfull()` to `Response` providing simple check whether the whole response (all of contained command responses) are successful (ie. none of them is invalid).
+This is also recommended way how to validate response successfulness.
+
 ### Changed
 - Invalid command inside recommendation/sorting request does not cause whole request to fail, rather the specific command response is marked as invalid.
 - Deprecated `CommandResponse::STATUS_ERROR`, because Matej no longer uses it (`CommandResponse::STATUS_INVALID` is instead used everywhere).

--- a/README.md
+++ b/README.md
@@ -69,12 +69,17 @@ $response = $matej->request()
 
 See below for examples of building request for each endpoint.
 
-To process the response:
+To **process the response**:
 
 ```php
 echo 'Number of commands: ' . $response->getNumberOfCommands() . "\n";
 echo 'Number of successful commands: ' . $response->getNumberOfSuccessfulCommands() . "\n";
-echo 'Number of failed commands: ' . $response->NumberOfFailedCommands()() . "\n";
+echo 'Number of failed commands: ' . $response->getNumberOfFailedCommands()() . "\n";
+
+// Use $response->isSuccessful() to check whether all of the commands send in request were successful or not:
+if (!$response->isSuccessful()) {
+    echo 'At least one command response was not succesful!';
+}
 
 // Iterate over getCommandResponses() to get response for each command passed to the builder.
 // Commands in the response are present in the same order as they were added to the requets builder.
@@ -402,8 +407,11 @@ $matej->request()
 Exceptions are thrown only if the whole Request to Matej failed (when sending, decoding, authenticating etc.) or if
 the library is used incorrectly. If the request is successfully delivered to Matej, **exception is not thrown** even
 if any (or maybe all) of the submitted commands (which were part of the request) were rejected by Matej.
-This means to make sure any individual CommandResponse was successful, you need to check its status
-(eg. using `isSuccessful()` method) or compare value of `getNumberOfSuccessfulCommands()` - see usage examples above.
+
+To check whether the whole Response (ie. all contained command responses) is successful, you thus MUST NOT rely on exceptions
+(because they won't be thrown - as stated above) but rather use `Response::isSuccessful()` method - see [usage examples](#usage) above.
+
+If you want to check which individual CommandResponse was successful, you can check its status using `CommandResponse::isSuccessful()` method.
 
 Exceptions occurring inside Matej API client implements `Lmc\Matej\Exception\MatejExceptionInterface`.
 The exception tree is:

--- a/src/Model/Response.php
+++ b/src/Model/Response.php
@@ -101,4 +101,9 @@ class Response
     {
         return $this->responseId;
     }
+
+    public function isSuccessful(): bool
+    {
+        return $this->getNumberOfFailedCommands() === 0;
+    }
 }

--- a/src/Model/Response/PlainResponse.php
+++ b/src/Model/Response/PlainResponse.php
@@ -9,11 +9,6 @@ use Lmc\Matej\Model\Response;
  */
 class PlainResponse extends Response
 {
-    public function isSuccessful(): bool
-    {
-        return $this->getCommandResponse(0)->isSuccessful();
-    }
-
     public function getData(): array
     {
         return $this->getCommandResponse(0)->getData();

--- a/tests/unit/Model/ResponseTest.php
+++ b/tests/unit/Model/ResponseTest.php
@@ -20,7 +20,8 @@ class ResponseTest extends UnitTestCase
         int $numberOfSuccessful,
         int $numberOfFailed,
         int $numberOfSkipped,
-        array $commandResponses
+        array $commandResponses,
+        bool $shouldBeSuccessful
     ): void {
         $responseId = uniqid((string) time());
         $response = new Response(
@@ -39,6 +40,8 @@ class ResponseTest extends UnitTestCase
 
         $this->assertSame($responseId, $response->getResponseId());
 
+        $this->assertSame($shouldBeSuccessful, $response->isSuccessful());
+
         $this->assertCount(count($commandResponses), $response->getCommandResponses());
         $this->assertContainsOnlyInstancesOf(CommandResponse::class, $response->getCommandResponses());
         for ($i = 0; $i < count($commandResponses); $i++) {
@@ -56,10 +59,13 @@ class ResponseTest extends UnitTestCase
         $skippedCommandResponse = (object) ['status' => CommandResponse::STATUS_SKIPPED, 'message' => '', 'data' => []];
 
         return [
-            'empty response data' => [0, 0, 0, 0, []],
-            'multiple successful commands' => [2, 2, 0, 0, [$okCommandResponse, $okCommandResponse]],
-            'multiple failed commands' => [2, 0, 2, 0, [$failedCommandResponse, $failedCommandResponse]],
-            'multiple skipped commands' => [2, 0, 0, 2, [$skippedCommandResponse, $skippedCommandResponse]],
+            'empty response data' => [0, 0, 0, 0, [], true],
+            'multiple ok commands' => [2, 2, 0, 0, [$okCommandResponse, $okCommandResponse], true],
+            'multiple failed commands' => [2, 0, 2, 0, [$failedCommandResponse, $failedCommandResponse], false],
+            'multiple skipped commands' => [2, 0, 0, 2, [$skippedCommandResponse, $skippedCommandResponse], true],
+            'ok and skipped command' => [2, 1, 0, 1, [$okCommandResponse, $skippedCommandResponse], true],
+            'ok and failed commands' => [2, 1, 1, 0, [$okCommandResponse, $failedCommandResponse], false],
+            'skipped and failed command' => [2, 0, 1, 1, [$skippedCommandResponse, $skippedCommandResponse], false],
             'multiple successful , failed and skipped commands' => [
                 5,
                 2,
@@ -72,6 +78,7 @@ class ResponseTest extends UnitTestCase
                     $skippedCommandResponse,
                     $failedCommandResponse,
                 ],
+                false,
             ],
         ];
     }


### PR DESCRIPTION
For simple check whether all contained command responses were successful.

This is also recommended way how to validate response successfulness.

If you don't need to process response (eg. when submitting events to Matej) you can now for example simply do this:

```php
public function submitDataToMatej(/*...*/): bool
    $response = $matej->request()
        ...
        ->send();
    
    // All commands were successful
    if ($response->isSuccessful()) {
        return true;
    }
    
    // At least one was not successful, so we log those
    foreach ($response->getCommandResponses() as $commandResponse) {
        if (!$commandResponse->isSuccessful()) {
            $this->logger->log('Command to Matej failed: ' . $commandResponse);
        }
    }
    
    return false;
}
```
