### PR TITLE
Minor codestyle fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,3 +475,10 @@ To run all those checks execute:
 ```sh
 $ composer all
 ```
+
+In case of codestyle violation you can run this command which will try to automatically fix the codestyle:
+
+
+```sh
+$ composer fix
+```

--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,10 @@
             "vendor/bin/ecs check src/ tests/ --ansi",
             "vendor/bin/phpstan analyze -c phpstan.neon --ansi"
         ],
+        "fix": [
+            "@composer normalize",
+            "./vendor/bin/ecs check ./src/ ./tests/ --ansi --fix"
+        ],
         "lint": [
             "vendor/bin/parallel-lint -j 10 ./src ./tests",
             "@composer validate",

--- a/src/Model/Command/Interaction.php
+++ b/src/Model/Command/Interaction.php
@@ -51,7 +51,11 @@ class Interaction extends AbstractCommand implements UserAwareInterface
         int $timestamp = null
     ): self {
         $interaction = new static(
-            $interactionType, $userId, self::DEFAULT_ITEM_ID_ALIAS, $itemId, $timestamp
+            $interactionType,
+            $userId,
+            self::DEFAULT_ITEM_ID_ALIAS,
+            $itemId,
+            $timestamp
         );
 
         return $interaction;
@@ -68,7 +72,11 @@ class Interaction extends AbstractCommand implements UserAwareInterface
         int $timestamp = null
     ): self {
         return new static(
-            $interactionType, $userId, $itemIdAlias, $itemId, $timestamp
+            $interactionType,
+            $userId,
+            $itemIdAlias,
+            $itemId,
+            $timestamp
         );
     }
 

--- a/tests/integration/RequestBuilder/InteractionRequestTest.php
+++ b/tests/integration/RequestBuilder/InteractionRequestTest.php
@@ -28,8 +28,9 @@ class InteractionRequestTest extends IntegrationTestCase
         $response = static::createMatejInstance()
             ->request()
             ->events()
-            ->addInteraction(Interaction::withItem('purchase', 'user-a', 'item-a')
-                ->setAttribute('quantity', 2)
+            ->addInteraction(
+                Interaction::withItem('purchase', 'user-a', 'item-a')
+                    ->setAttribute('quantity', 2)
             )
             ->send();
 

--- a/tests/integration/RequestBuilder/RecommendationRequestBuilderTest.php
+++ b/tests/integration/RequestBuilder/RecommendationRequestBuilderTest.php
@@ -22,8 +22,9 @@ class RecommendationRequestBuilderTest extends IntegrationTestCase
     {
         $response = static::createMatejInstance()
             ->request()
-            ->recommendation($this->createRecommendationCommand('user-a')
-                ->addBoost(Boost::create('age > 1', 1.2))
+            ->recommendation(
+                $this->createRecommendationCommand('user-a')
+                    ->addBoost(Boost::create('age > 1', 1.2))
             )->send();
 
         $this->assertInstanceOf(RecommendationsResponse::class, $response);
@@ -93,9 +94,8 @@ class RecommendationRequestBuilderTest extends IntegrationTestCase
         $this->assertSame(1, $response->getNumberOfSuccessfulCommands());
         $response = $matej
             ->request()
-            ->recommendation($this->createRecommendationCommand('user-a')
-                ->addFilter('for_recommendation = 1')
-            )->send();
+            ->recommendation($this->createRecommendationCommand('user-a')->addFilter('for_recommendation = 1'))
+            ->send();
         $this->assertInstanceOf(RecommendationsResponse::class, $response);
         $this->assertResponseCommandStatuses($response, 'SKIPPED', 'SKIPPED', 'OK');
         $this->assertShorthandResponse($response, 'SKIPPED', 'SKIPPED', 'OK');

--- a/tests/unit/Http/Plugin/ExceptionPluginTest.php
+++ b/tests/unit/Http/Plugin/ExceptionPluginTest.php
@@ -31,7 +31,7 @@ class ExceptionPluginTest extends TestCase
         };
 
         $plugin = new ExceptionPlugin();
-        $promise = $plugin->handleRequest($request, $next, function() use ($response): Promise {
+        $promise = $plugin->handleRequest($request, $next, function () use ($response): Promise {
             return new HttpFulfilledPromise($response);
         });
         $this->assertInstanceOf(HttpFulfilledPromise::class, $promise);
@@ -66,7 +66,7 @@ class ExceptionPluginTest extends TestCase
 
         $plugin = new ExceptionPlugin();
 
-        $promise = $plugin->handleRequest($request, $next, function() use ($response): Promise {
+        $promise = $plugin->handleRequest($request, $next, function () use ($response): Promise {
             return new HttpFulfilledPromise($response);
         });
 

--- a/tests/unit/Model/Command/InteractionTest.php
+++ b/tests/unit/Model/Command/InteractionTest.php
@@ -128,7 +128,8 @@ class InteractionTest extends TestCase
     {
         /** @var Interaction $command */
         $command = forward_static_call_array(
-            [Interaction::class, 'withItem'], $constructorParams
+            [Interaction::class, 'withItem'],
+            $constructorParams
         );
 
         $this->assertInstanceOf(Interaction::class, $command);
@@ -157,7 +158,8 @@ class InteractionTest extends TestCase
     {
         /** @var Interaction $command */
         $command = forward_static_call_array(
-            [Interaction::class, 'withAliasedItem'], $constructorParams
+            [Interaction::class, 'withAliasedItem'],
+            $constructorParams
         );
 
         $this->assertInstanceOf(Interaction::class, $command);


### PR DESCRIPTION
There was [a bug](https://github.com/lmc-eu/php-coding-standard/pull/42) in the codestyle check because of which some codestyle errors were not properly reported. 

This fixes it, so that it won't break the build once new version of `php-coding-standard` is released.

Also new `composer fix` command was added for easy an automatic codestyle fix.