### PR TITLE
Change dash in item-id property name to underscore for backward compatibility

### DIFF
--- a/src/Model/RecommendationCommandResponse.php
+++ b/src/Model/RecommendationCommandResponse.php
@@ -16,7 +16,7 @@ class RecommendationCommandResponse extends CommandResponse
            consistent format. */
         foreach ($this->data as $key => $val) {
             if (is_string($val)) {
-                $val = (object) ['item-id' => $val];
+                $val = (object) ['item_id' => $val];
             }
             $data[$key] = $val;
         }

--- a/tests/unit/Model/Response/RecommendationsResponseTest.php
+++ b/tests/unit/Model/Response/RecommendationsResponseTest.php
@@ -47,14 +47,14 @@ class RecommendationsResponseTest extends UnitTestCase
 
         $this->assertTrue($response->getRecommendation()->isSuccessful());
         $this->assertSame('MOCK_RECOMMENDATION_MESSAGE', $response->getRecommendation()->getMessage());
-        $this->assertEquals([(object) ['item-id' => 'MOCK_ITEM_ID']], $response->getRecommendation()->getData());
+        $this->assertEquals([(object) ['item_id' => 'MOCK_ITEM_ID']], $response->getRecommendation()->getData());
     }
 
     public function provideRecommendationResponseData(): array
     {
         return [
             'complex response data' => [
-                [(object) ['item-id' => 'MOCK_ITEM_ID']],
+                [(object) ['item_id' => 'MOCK_ITEM_ID']],
             ],
             'flat response data' => [
                 ['MOCK_ITEM_ID'],


### PR DESCRIPTION
I found a bug in https://github.com/lmc-eu/matej-client-php/pull/123 which caused that we wasnt able to process response from matej client.