### PR TITLE
Add method resetData for ability to reset collection without deleting configured scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,21 @@ $response = $matej->request()
 var_dump($response->isSuccessful()); // true on success
 ```
 
+### Reset data
+
+Data (users and items) of test accounts (those ending with `-test`) could be reset via the API.
+Using this you can delete all data while keeping database setup (item properties, scenarios).
+
+```php
+$matej = new Matej('accountId', 'apikey');
+
+$response = $matej->request()
+    ->resetData()
+    ->send();
+
+var_dump($response->isSuccessful()); // true on success
+```
+
 ### Send Events data to Matej
 
 You can use `events()` builder for sending batch of following commands to Matej:

--- a/src/RequestBuilder/RequestBuilderFactory.php
+++ b/src/RequestBuilder/RequestBuilderFactory.php
@@ -98,6 +98,14 @@ class RequestBuilderFactory
         return $requestBuilder;
     }
 
+    public function resetData(): ResetDataRequestBuilder
+    {
+        $requestBuilder = new ResetDataRequestBuilder();
+        $this->setupBuilder($requestBuilder);
+
+        return $requestBuilder;
+    }
+
     private function setupBuilder(AbstractRequestBuilder $requestBuilder): void
     {
         $requestBuilder->setRequestManager($this->requestManager);

--- a/src/RequestBuilder/ResetDataRequestBuilder.php
+++ b/src/RequestBuilder/ResetDataRequestBuilder.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\RequestBuilder;
+
+use Fig\Http\Message\RequestMethodInterface;
+use Lmc\Matej\Model\Request;
+use Lmc\Matej\Model\Response\PlainResponse;
+
+/**
+ * @method PlainResponse send()
+ */
+class ResetDataRequestBuilder extends AbstractRequestBuilder
+{
+    protected const ENDPOINT_PATH = '/data';
+
+    public function build(): Request
+    {
+        return new Request(
+            self::ENDPOINT_PATH,
+            RequestMethodInterface::METHOD_DELETE,
+            [],
+            $this->requestId,
+            PlainResponse::class
+        );
+    }
+}

--- a/tests/integration/RequestBuilder/ResetDataRequestBuilderTest.php
+++ b/tests/integration/RequestBuilder/ResetDataRequestBuilderTest.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\IntegrationTests\RequestBuilder;
+
+use Lmc\Matej\IntegrationTests\IntegrationTestCase;
+
+/**
+ * @covers \Lmc\Matej\Model\Response\PlainResponse
+ * @covers \Lmc\Matej\RequestBuilder\ResetDataRequestBuilder
+ */
+class ResetDataRequestBuilderTest extends IntegrationTestCase
+{
+    /** @test */
+    public function shouldResetMatejData(): void
+    {
+        $response = static::createMatejInstance()
+            ->request()
+            ->resetData()
+            ->send();
+
+        $this->assertResponseCommandStatuses($response, 'OK');
+        $this->assertTrue($response->isSuccessful());
+        $this->assertSame('', $response->getMessage());
+        $this->assertSame('OK', $response->getStatus());
+        $this->assertIsArray($response->getData());
+    }
+}

--- a/tests/unit/RequestBuilder/RequestBuilderFactoryTest.php
+++ b/tests/unit/RequestBuilder/RequestBuilderFactoryTest.php
@@ -99,6 +99,7 @@ class RequestBuilderFactoryTest extends TestCase
             'recommendation' => ['recommendation', RecommendationRequestBuilder::class, $voidInit, $userRecommendation],
             'forget' => ['forget', ForgetRequestBuilder::class, $forgetInit],
             'resetDatabase' => ['resetDatabase', ResetDatabaseRequestBuilder::class, $voidInit],
+            'resetData' => ['resetData', ResetDataRequestBuilder::class, $voidInit],
         ];
     }
 }

--- a/tests/unit/RequestBuilder/ResetDataRequestBuilderTest.php
+++ b/tests/unit/RequestBuilder/ResetDataRequestBuilderTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Matej\RequestBuilder;
+
+use Fig\Http\Message\RequestMethodInterface;
+use Lmc\Matej\Exception\LogicException;
+use Lmc\Matej\Http\RequestManager;
+use Lmc\Matej\Model\Request;
+use Lmc\Matej\Model\Response;
+use Lmc\Matej\UnitTestCase;
+
+/**
+ * @covers \Lmc\Matej\RequestBuilder\ResetDataRequestBuilder
+ */
+class ResetDataRequestBuilderTest extends UnitTestCase
+{
+    /** @test */
+    public function shouldBuildRequestWithCommands(): void
+    {
+        $builder = new ResetDataRequestBuilder();
+        $builder->setRequestId('custom-request-id-foo');
+
+        $request = $builder->build();
+
+        $this->assertSame(RequestMethodInterface::METHOD_DELETE, $request->getMethod());
+        $this->assertSame('/data', $request->getPath());
+        $this->assertEmpty($request->getData());
+        $this->assertSame('custom-request-id-foo', $request->getRequestId());
+    }
+
+    /** @test */
+    public function shouldThrowExceptionWhenSendingCommandsWithoutRequestManager(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Instance of RequestManager must be set to request builder');
+
+        $builder = new ResetDataRequestBuilder();
+        $builder->send();
+    }
+
+    /** @test */
+    public function shouldSendRequestViaRequestManager(): void
+    {
+        $requestManagerMock = $this->createMock(RequestManager::class);
+        $requestManagerMock->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->isInstanceOf(Request::class))
+            ->willReturn(new Response(0, 0, 0, 0));
+
+        $builder = new ResetDataRequestBuilder();
+        $builder->setRequestManager($requestManagerMock);
+        $builder->send();
+    }
+}


### PR DESCRIPTION
This PR adds a resetData method as requested in https://github.com/lmc-eu/matej-client-php/issues/125