### PR TITLE
Remove superfluous assertions and annotations

### DIFF
--- a/easy-coding-standard.yaml
+++ b/easy-coding-standard.yaml
@@ -10,7 +10,3 @@ parameters:
         # Skip class suffix sniff for Matej Commands
         Symplify\CodingStandard\Sniffs\Naming\ClassNameSuffixByParentSniff:
             - 'src/Model/Command/*.php'
-        # Intentional superfluous annotations making PHP5 version easier to use
-        PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer:
-            - 'src/Model/Command/UserRecommendation.php'
-            - 'src/RequestBuilder/AbstractRequestBuilder.php'

--- a/src/Model/Command/UserRecommendation.php
+++ b/src/Model/Command/UserRecommendation.php
@@ -47,7 +47,6 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
     }
 
     /**
-     * @param string $userId
      * @param string $scenario Name of the place where recommendations are applied - eg. 'search-results-page',
      * 'emailing', 'empty-search-results, 'homepage', ...
      * @return static
@@ -116,7 +115,6 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
     /**
      * Add another response property you want returned. item_id is always returned by Matej.
      *
-     * @param string $property
      * @return $this
      */
     public function addResponseProperty(string $property): self
@@ -222,7 +220,6 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
     /**
      * Set how much should the item be penalized for being recommended again in the near future.
      *
-     * @param float $rotationRate
      * @return $this
      */
     public function setRotationRate(float $rotationRate): self
@@ -238,7 +235,6 @@ class UserRecommendation extends AbstractCommand implements UserAwareInterface
      * Specify for how long will the item's rotationRate be taken in account and so the item is penalized for
      * recommendations.
      *
-     * @param int $rotationTime
      * @return $this
      */
     public function setRotationTime(int $rotationTime): self

--- a/src/RequestBuilder/AbstractRequestBuilder.php
+++ b/src/RequestBuilder/AbstractRequestBuilder.php
@@ -53,9 +53,6 @@ abstract class AbstractRequestBuilder
         return $this;
     }
 
-    /**
-     * @return Response
-     */
     public function send(): Response
     {
         $this->assertRequestManagerIsAvailable();

--- a/tests/integration/RequestBuilder/RecommendationRequestBuilderTest.php
+++ b/tests/integration/RequestBuilder/RecommendationRequestBuilderTest.php
@@ -8,7 +8,6 @@ use Lmc\Matej\Model\Command\Boost;
 use Lmc\Matej\Model\Command\Interaction;
 use Lmc\Matej\Model\Command\UserMerge;
 use Lmc\Matej\Model\Command\UserRecommendation;
-use Lmc\Matej\Model\CommandResponse;
 use Lmc\Matej\Model\Response\RecommendationsResponse;
 
 /**
@@ -115,9 +114,6 @@ class RecommendationRequestBuilderTest extends IntegrationTestCase
         string $userMergeStatus,
         string $recommendationStatus
     ): void {
-        $this->assertInstanceOf(CommandResponse::class, $response->getInteraction());
-        $this->assertInstanceOf(CommandResponse::class, $response->getUserMerge());
-        $this->assertInstanceOf(CommandResponse::class, $response->getRecommendation());
         $this->assertSame($interactionStatus, $response->getInteraction()->getStatus());
         $this->assertSame($userMergeStatus, $response->getUserMerge()->getStatus());
         $this->assertSame($recommendationStatus, $response->getRecommendation()->getStatus());

--- a/tests/integration/RequestBuilder/SortingRequestTest.php
+++ b/tests/integration/RequestBuilder/SortingRequestTest.php
@@ -6,7 +6,6 @@ use Lmc\Matej\IntegrationTests\IntegrationTestCase;
 use Lmc\Matej\Model\Command\Interaction;
 use Lmc\Matej\Model\Command\Sorting;
 use Lmc\Matej\Model\Command\UserMerge;
-use Lmc\Matej\Model\CommandResponse;
 use Lmc\Matej\Model\Response\SortingResponse;
 
 /**
@@ -62,9 +61,6 @@ class SortingRequestTest extends IntegrationTestCase
         string $userMergeStatus,
         string $sortingStatus
     ): void {
-        $this->assertInstanceOf(CommandResponse::class, $response->getInteraction());
-        $this->assertInstanceOf(CommandResponse::class, $response->getUserMerge());
-        $this->assertInstanceOf(CommandResponse::class, $response->getSorting());
         $this->assertSame($interactionStatus, $response->getInteraction()->getStatus());
         $this->assertSame($userMergeStatus, $response->getUserMerge()->getStatus());
         $this->assertSame($sortingStatus, $response->getSorting()->getStatus());

--- a/tests/unit/Exception/AuthorizationExceptionTest.php
+++ b/tests/unit/Exception/AuthorizationExceptionTest.php
@@ -22,7 +22,6 @@ class AuthorizationExceptionTest extends UnitTestCase
 
         $exception = AuthorizationException::fromRequestAndResponse($request, $response);
 
-        $this->assertInstanceOf(AuthorizationException::class, $exception);
         $this->assertSame(
             'Matej API authorization error for url "/endpoint" (Invalid signature. Check your secret key)',
             $exception->getMessage()

--- a/tests/unit/Http/RequestManagerTest.php
+++ b/tests/unit/Http/RequestManagerTest.php
@@ -37,10 +37,8 @@ class RequestManagerTest extends UnitTestCase
             'custom-request-id'
         );
 
-        $matejResponse = $requestManager->sendRequest($request);
-
-        // Request should be decoded to Matej Response; decoding itself is comprehensively tested in ResponseDecoderTest
-        $this->assertInstanceOf(Response::class, $matejResponse);
+        // Response decoding is comprehensively tested in ResponseDecoderTest
+        $requestManager->sendRequest($request);
 
         // Assert properties of the send request
         $recordedRequests = $mockClient->getRequests();

--- a/tests/unit/Model/Command/ItemPropertyTest.php
+++ b/tests/unit/Model/Command/ItemPropertyTest.php
@@ -25,7 +25,6 @@ class ItemPropertyTest extends TestCase
     {
         $command = ItemProperty::create('exampleItemId', $properties);
 
-        $this->assertInstanceOf(ItemProperty::class, $command);
         $this->assertSame(
             [
                 'type' => 'item-properties',

--- a/tests/unit/Model/Command/UserRecommendationTest.php
+++ b/tests/unit/Model/Command/UserRecommendationTest.php
@@ -12,7 +12,6 @@ class UserRecommendationTest extends TestCase
     {
         $command = UserRecommendation::create('user-id', 'test-scenario');
 
-        $this->assertInstanceOf(UserRecommendation::class, $command);
         $this->assertEquals(
             [
                 'type' => 'user-based-recommendations',
@@ -49,8 +48,6 @@ class UserRecommendationTest extends TestCase
             ->addResponseProperty('item_url')
             ->addBoost(Boost::create('valid_to >= NOW()', 1.0))
             ->addBoost(Boost::create('custom = argument', 2.0));
-
-        $this->assertInstanceOf(UserRecommendation::class, $command);
 
         $this->assertEquals(
             [

--- a/tests/unit/Model/CommandResponseTest.php
+++ b/tests/unit/Model/CommandResponseTest.php
@@ -19,7 +19,6 @@ class CommandResponseTest extends UnitTestCase
     ): void {
         $commandResponse = CommandResponse::createFromRawCommandResponseObject($objectResponse);
 
-        $this->assertInstanceOf(CommandResponse::class, $commandResponse);
         $this->assertSame($expectedStatus, $commandResponse->getStatus());
         $this->assertSame($expectedMessage, $commandResponse->getMessage());
         $this->assertSame($expectedData, $commandResponse->getData());

--- a/tests/unit/Model/ResponseTest.php
+++ b/tests/unit/Model/ResponseTest.php
@@ -45,7 +45,7 @@ class ResponseTest extends UnitTestCase
         $this->assertCount(count($commandResponses), $response->getCommandResponses());
         $this->assertContainsOnlyInstancesOf(CommandResponse::class, $response->getCommandResponses());
         for ($i = 0; $i < count($commandResponses); $i++) {
-            $this->assertInstanceOf(CommandResponse::class, $response->getCommandResponse($i));
+            $this->assertNotEmpty($response->getCommandResponse($i));
         }
     }
 

--- a/tests/unit/RequestBuilder/CampaignRequestBuilderTest.php
+++ b/tests/unit/RequestBuilder/CampaignRequestBuilderTest.php
@@ -52,7 +52,6 @@ class CampaignRequestBuilderTest extends TestCase
 
         $request = $builder->build();
 
-        $this->assertInstanceOf(Request::class, $request);
         $this->assertSame(RequestMethodInterface::METHOD_POST, $request->getMethod());
         $this->assertSame('/campaign', $request->getPath());
 

--- a/tests/unit/RequestBuilder/EventsRequestBuilderTest.php
+++ b/tests/unit/RequestBuilder/EventsRequestBuilderTest.php
@@ -46,7 +46,6 @@ class EventsRequestBuilderTest extends TestCase
 
         $request = $builder->build();
 
-        $this->assertInstanceOf(Request::class, $request);
         $this->assertSame(RequestMethodInterface::METHOD_POST, $request->getMethod());
         $this->assertSame('/events', $request->getPath());
 

--- a/tests/unit/RequestBuilder/ForgetRequestBuilderTest.php
+++ b/tests/unit/RequestBuilder/ForgetRequestBuilderTest.php
@@ -36,7 +36,6 @@ class ForgetRequestBuilderTest extends TestCase
 
         $request = $builder->build();
 
-        $this->assertInstanceOf(Request::class, $request);
         $this->assertSame(RequestMethodInterface::METHOD_POST, $request->getMethod());
         $this->assertSame('/forget', $request->getPath());
 

--- a/tests/unit/RequestBuilder/ItemPropertiesGetRequestBuilderTest.php
+++ b/tests/unit/RequestBuilder/ItemPropertiesGetRequestBuilderTest.php
@@ -22,7 +22,6 @@ class ItemPropertiesGetRequestBuilderTest extends UnitTestCase
 
         $request = $builder->build();
 
-        $this->assertInstanceOf(Request::class, $request);
         $this->assertSame(RequestMethodInterface::METHOD_GET, $request->getMethod());
         $this->assertSame('/item-properties', $request->getPath());
         $this->assertEmpty($request->getData());

--- a/tests/unit/RequestBuilder/ItemPropertiesSetupRequestBuilderTest.php
+++ b/tests/unit/RequestBuilder/ItemPropertiesSetupRequestBuilderTest.php
@@ -36,7 +36,6 @@ class ItemPropertiesSetupRequestBuilderTest extends TestCase
 
         $request = $builder->build();
 
-        $this->assertInstanceOf(Request::class, $request);
         $this->assertSame($expectedMethod, $request->getMethod());
         $this->assertSame('/item-properties', $request->getPath());
         $this->assertContainsOnlyInstancesOf(ItemPropertySetup::class, $request->getData());

--- a/tests/unit/RequestBuilder/RecommendationRequestBuilderTest.php
+++ b/tests/unit/RequestBuilder/RecommendationRequestBuilderTest.php
@@ -39,7 +39,6 @@ class RecommendationRequestBuilderTest extends TestCase
 
         $request = $builder->build();
 
-        $this->assertInstanceOf(Request::class, $request);
         $this->assertSame(RequestMethodInterface::METHOD_POST, $request->getMethod());
         $this->assertSame('/recommendations', $request->getPath());
 
@@ -143,7 +142,7 @@ class RecommendationRequestBuilderTest extends TestCase
         $builder = new RecommendationRequestBuilder($recommendationsCommand);
         $builder->setUserMerge($userMergeCommand);
         $builder->setInteraction($interactionCommand);
-        $this->assertInstanceOf(Request::class, $builder->build());
+        $this->assertNotEmpty($builder->build());
     }
 
     /**

--- a/tests/unit/RequestBuilder/RequestBuilderFactoryTest.php
+++ b/tests/unit/RequestBuilder/RequestBuilderFactoryTest.php
@@ -42,10 +42,9 @@ class RequestBuilderFactoryTest extends TestCase
         $minimalBuilderInit($builder);
 
         $this->assertInstanceOf($expectedBuilderClass, $builder);
-        $this->assertInstanceOf(Request::class, $builder->build());
 
         // Make sure the builder has been properly configured and it can execute send() via RequestManager mock:
-        $this->assertInstanceOf(Response::class, $builder->send());
+        $this->assertNotEmpty($builder->send());
     }
 
     /**

--- a/tests/unit/RequestBuilder/ResetDatabaseRequestBuilderTest.php
+++ b/tests/unit/RequestBuilder/ResetDatabaseRequestBuilderTest.php
@@ -22,7 +22,6 @@ class ResetDatabaseRequestBuilderTest extends UnitTestCase
 
         $request = $builder->build();
 
-        $this->assertInstanceOf(Request::class, $request);
         $this->assertSame(RequestMethodInterface::METHOD_DELETE, $request->getMethod());
         $this->assertSame('/database', $request->getPath());
         $this->assertEmpty($request->getData());

--- a/tests/unit/RequestBuilder/SortingRequestBuilderTest.php
+++ b/tests/unit/RequestBuilder/SortingRequestBuilderTest.php
@@ -36,7 +36,6 @@ class SortingRequestBuilderTest extends TestCase
 
         $request = $builder->build();
 
-        $this->assertInstanceOf(Request::class, $request);
         $this->assertSame(RequestMethodInterface::METHOD_POST, $request->getMethod());
         $this->assertSame('/sorting', $request->getPath());
 
@@ -116,7 +115,7 @@ class SortingRequestBuilderTest extends TestCase
         $builder = new SortingRequestBuilder($sortingCommand);
         $builder->setUserMerge($userMergeCommand);
         $builder->setInteraction($interactionCommand);
-        $this->assertInstanceOf(Request::class, $builder->build());
+        $this->assertNotEmpty($builder->build());
     }
 
     /**


### PR DESCRIPTION
Those were used for easier use and tests of [PHP 5 client](https://github.com/lmc-eu/matej-client-php5). Since we no longer support it, those assertions and annotations could be safely removed.