### PR TITLE
Remove no longer necessary phpstan's ignored error

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,8 +9,6 @@ parameters:
         - '#Unsafe usage of new static\(\)#'
         - message: '#expects class-string#'
           path: tests/
-        - message: '#Unable to resolve the template type ExpectedType#'
-          path: tests/unit/RequestBuilder/RequestBuilderFactoryTest.php
         - message: '#parameter \$factoryArguments with no typehint specified#'
           path: tests/unit/RequestBuilder/RequestBuilderFactoryTest.php
 


### PR DESCRIPTION
Fix phpstan error causing build to fail. This ignoreError is no longer necessary, as of PHPStan 0.12.67 (fixed in https://github.com/phpstan/phpstan/issues/3853).