### PR TITLE
Items filtering trait: Convert boosts array to list.

### DIFF
--- a/src/Model/Command/ItemsFilteringTrait.php
+++ b/src/Model/Command/ItemsFilteringTrait.php
@@ -82,10 +82,11 @@ trait ItemsFilteringTrait
 
     /**
      * Set boosts. Removes all previously set rules.
+     * @param Boost[] $boosts
      */
     public function setBoosts(array $boosts): self
     {
-        $this->boosts = $boosts;
+        $this->boosts = array_values($boosts);
 
         return $this;
     }


### PR DESCRIPTION
Just fix bug from Seduo.

Matej should convert the boost array to a list if it does not contain properly indexed keys.